### PR TITLE
specified namespace for rowMeans function in the custom vignette

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ cache: packages
 
 warnings_are_errors: false
 
+env:
+    - R_REMOTES_UPGRADE="always"
+
 before_install:
     - Rscript -e 'install.packages("devtools")'
     - Rscript -e 'devtools::install(dependencies=TRUE)'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,8 @@ Suggests:
     RColorBrewer,
     viridis,
     org.Mm.eg.db,
-    htmltools
+    htmltools,
+    Matrix
 URL: https://github.com/csoneson/iSEE
 BugReports: https://github.com/csoneson/iSEE/issues
 biocViews: ImmunoOncology, Visualization, GUI, DimensionReduction, 

--- a/R/codeTracker.R
+++ b/R/codeTracker.R
@@ -374,7 +374,7 @@
         curcode <- list(strrep("#", 80),
                 sprintf("# Settings for %ss", tolower(panelTypes[mode])),
                 strrep("#", 80), "", 
-                sprintf("%s <- new('DataFrame', nrows=%iL, rownames=paste0('%s', seq_len(%i)))", arg_obj, Npanels, mode, Npanels))
+                sprintf("%s <- new('DataFrame', nrows=%iL, rownames=sprintf('%s%%i', seq_len(%i)))", arg_obj, Npanels, mode, Npanels))
 
         for (field in colnames(current)) {
             curvals <- current[[field]]

--- a/R/shinyjs.R
+++ b/R/shinyjs.R
@@ -28,3 +28,4 @@
     }
     invisible(NULL)
 }
+# nocov end

--- a/tests/testthat/test_zzz.R
+++ b/tests/testthat/test_zzz.R
@@ -2,10 +2,13 @@ context("zzz")
 
 test_that("onLoad works", {
 
+    # Provide code coverage
     iSEE:::.onLoad()
 
-    directoryPath <- normalizePath(shiny:::.globals$resources[["iSEE"]][["directoryPath"]])
-    expectedPath <- normalizePath(system.file("www", package="iSEE"))
+    # To make an "expect_" statement, we would have to toy with shiny internals.
+    
+    # directoryPath <- normalizePath(shiny:::.globals$resourcePaths[["iSEE"]][["path"]])
+    # expectedPath <- normalizePath(system.file("www", package="iSEE"))
     # expect_identical(directoryPath, expectedPath)
 
 })

--- a/vignettes/custom.Rmd
+++ b/vignettes/custom.Rmd
@@ -246,11 +246,11 @@ CUSTOM_DIFFEXP <- function(se, ri, ci, assay="logcounts") {
     }
 
     assayMatrix <- assay(se, assay)[ri, , drop=FALSE]
-    active <- rowMeans(assayMatrix[,ci$active,drop=FALSE])
+    active <- Matrix::rowMeans(assayMatrix[,ci$active,drop=FALSE])
 
     lfcs <- vector("list", length(ci$saved))
     for (i in seq_along(lfcs)) {
-        saved <- rowMeans(assayMatrix[,ci$saved[[i]],drop=FALSE])
+        saved <- Matrix::rowMeans(assayMatrix[,ci$saved[[i]],drop=FALSE])
         lfcs[[i]] <- active - saved
     }
     names(lfcs) <- sprintf("LogFC/%i", seq_along(lfcs))
@@ -271,7 +271,7 @@ CUSTOM_HEAT <- function(se, ri, ci, assay="logcounts") {
     }
 
     everything <- as.matrix(everything)
-    top <- head(order(rowMeans(abs(everything)), decreasing=TRUE), 50)
+    top <- head(order(Matrix::rowMeans(abs(everything)), decreasing=TRUE), 50)
     topFC <- everything[top, , drop=FALSE]
     dimnames(topFC) <- list(gene=rownames(topFC), contrast=colnames(topFC))
     dfFC <- reshape2::melt(topFC)
@@ -328,8 +328,8 @@ CUSTOM_LFC <- function(se, rows, columns) {
 
     if (!identical(caching$columns, columns)) {
         caching$columns <- columns
-        in.subset <- rowMeans(logcounts(sce)[,columns])
-        out.subset <- rowMeans(logcounts(sce)[,setdiff(colnames(sce), columns)])
+        in.subset <- Matrix::rowMeans(logcounts(sce)[,columns])
+        out.subset <- Matrix::rowMeans(logcounts(sce)[,setdiff(colnames(sce), columns)])
         caching$logFC <- setNames(in.subset - out.subset, rownames(sce))
     } 
        


### PR DESCRIPTION
A simple edit in the custom vignette.

In settings where the user might have also other packages loaded, it probably helps to disambiguate which function needs to be called.

@LTLA: I did change only in some spots where I thought it was necessary. Is it safe to replace it in all the occurrences?
