### PR TITLE
Fix warnings and clean up tracked code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: iSEE
 Title: Interactive SummarizedExperiment Explorer
-Version: 1.5.7
+Version: 1.5.8
 Date: 2019-08-17
 Authors@R: c(person("Kevin", "Rue-Albrecht", role = "aut", email = "kevin.rue-albrecht@kennedy.ox.ac.uk", comment = c(ORCID = "0000-0003-3899-3872")),
     person("Federico", "Marini", role="aut", email="marinif@uni-mainz.de", comment = c(ORCID = '0000-0003-3252-7758')),

--- a/R/ExperimentColorMap.R
+++ b/R/ExperimentColorMap.R
@@ -615,8 +615,7 @@ setMethod(
 #' # Example SingleCellExperiment ----
 #'
 #' library(scRNAseq)
-#' sce <- ReprocessedAllenData(assays = "tophat_counts")
-#' library(scater)
+#' sce <- ReprocessedAllenData(assays="tophat_counts")
 #'
 #' # Test for compatibility ----
 #'
@@ -780,10 +779,9 @@ isColorMapCompatible <- function(ecm, se, error = FALSE){
 #' # Example SingleCellExperiment ----
 #'
 #' library(scRNAseq)
-#' sce <- ReprocessedAllenData(assays = "tophat_counts")
+#' sce <- ReprocessedAllenData(assays="tophat_counts")
 #' library(scater)
-#' counts(sce) <- assay(sce, "tophat_counts")
-#' sce <- normalize(sce)
+#' sce <- logNormCounts(sce, exprs_values="tophat_counts")
 #' sce <- runPCA(sce)
 #' sce <- runTSNE(sce)
 #'

--- a/R/annotation.R
+++ b/R/annotation.R
@@ -24,7 +24,7 @@
 #'
 #' @examples
 #' library(scRNAseq)
-#' sce <- ReprocessedAllenData(assays = "tophat_counts")
+#' sce <- ReprocessedAllenData(assays="tophat_counts")
 #'
 #' library(org.Mm.eg.db)
 #' myfun <- annotateEntrez(sce, org.Mm.eg.db, keytype="SYMBOL")
@@ -103,7 +103,7 @@ annotateEntrez <- function(se, orgdb, keytype, rowdata_col = NULL) {
 #'
 #' @examples
 #' library(scRNAseq)
-#' sce <- ReprocessedAllenData(assays = "tophat_counts")
+#' sce <- ReprocessedAllenData(assays="tophat_counts")
 #' library(org.Mm.eg.db)
 #' myfun <- annotateEnsembl(sce, org.Mm.eg.db, keytype="SYMBOL")
 #' \dontrun{

--- a/R/heatmap.R
+++ b/R/heatmap.R
@@ -54,7 +54,7 @@
     data_cmds <- .add_command(data_cmds, c(
       sprintf("value.mat <- as.matrix(assay(se, %i)[%s, , drop=FALSE]);",
               assay_choice, paste(deparse(genes_selected_y), collapse="\n")),
-      "plot.data <- reshape2::melt(value.mat, varnames = c('Y', 'X'));"
+      "plot.data <- reshape2::melt(value.mat, varnames=c('Y', 'X'));"
     ))
 
     # Arrange cells according to the selected colData columns
@@ -75,8 +75,8 @@
             }
         }, FUN.VALUE=character(1)),
         sprintf("plot.data <- dplyr::arrange(plot.data, %s);",
-                paste0("OrderBy", seq_along(orderBy), collapse = ",")),
-        "plot.data$X <- factor(plot.data$X, levels = unique(plot.data$X));"
+                paste0("OrderBy", seq_along(orderBy), collapse=",")),
+        "plot.data$X <- factor(plot.data$X, levels=unique(plot.data$X));"
     ))
 
     data_cmds <- .evaluate_commands(data_cmds, eval_env)
@@ -126,7 +126,7 @@
     bounds <- param_choices[[.zoomData]][[1]]
     if (!is.null(bounds)) {
         zoom_cmds <- sprintf("plot.data <- subset(plot.data, Y %%in%% rownames(value.mat)[c(%s)]); # zooming in",
-                             paste0(bounds, collapse = ","))
+                             paste0(bounds, collapse=","))
         .text_eval(zoom_cmds, eval_env)
     } else {
         zoom_cmds <- NULL
@@ -135,8 +135,8 @@
     # Heatmap. Get the colorbar separately to make it easier to guess the real
     # heatmap coordinates from a brush on the final combined plot
     plot_cmds <- c(
-        "p0 <- ggplot(plot.data, aes(x = X, y = Y)) +",
-        "geom_raster(aes(fill = value)) +",
+        "p0 <- ggplot(plot.data, aes(x=X, y=Y)) +",
+        "geom_raster(aes(fill=value)) +",
         "labs(x='', y='') +",
         .get_heatmap_fill_cmd(param_choices, colormap,
                               min(eval_env$plot.data$value, na.rm=TRUE),
@@ -159,31 +159,31 @@
         }
 
         annot_cmds[[paste0("OrderBy", i)]] <- c("",
-            sprintf("p%i <- ggplot(plot.data, aes(x = X, y = 1)) +", i) ,
-            sprintf("geom_raster(aes(fill = OrderBy%i%s)) +", i, alpha_cmd),
+            sprintf("p%i <- ggplot(plot.data, aes(x=X, y=1)) +", i) ,
+            sprintf("geom_raster(aes(fill=OrderBy%i%s)) +", i, alpha_cmd),
             "labs(x='', y='') +",
             alpha_legend_cmd,
             sprintf("scale_y_continuous(breaks=1, labels='%s') +", orderBy[i]),
             color_cmd,
             "theme(axis.text.x=element_blank(), axis.ticks=element_blank(), axis.title.x=element_blank(),
     rect=element_blank(), line=element_blank(), axis.title.y=element_blank(),
-    plot.margin = unit(c(0,0,-0.5,0), 'lines'));",
-            sprintf("legends[[%i]] <- cowplot::get_legend(p%i + theme(legend.position='bottom', plot.margin = unit(c(0,0,0,0), 'lines')));", i, i)
+    plot.margin=unit(c(0,0,-0.5,0), 'lines'));",
+            sprintf("legends[[%i]] <- cowplot::get_legend(p%i + theme(legend.position='bottom', plot.margin=unit(c(0,0,0,0), 'lines')));", i, i)
         )
     }
 
     if (select_as_field %in% orderBy) {
         i <- which(orderBy==select_as_field)
         annot_cmds[["SelectBy"]] <- c("",
-            sprintf("p%i <- ggplot(plot.data, aes(x = X, y = 1)) +", i),
-            "geom_raster(aes(fill = SelectBy)) +",
+            sprintf("p%i <- ggplot(plot.data, aes(x=X, y=1)) +", i),
+            "geom_raster(aes(fill=SelectBy)) +",
             "labs(x='', y='') +",
             "scale_y_continuous(breaks=1, labels='Selected points') +",
             sprintf("scale_fill_manual(values=c(`TRUE`='%s', `FALSE`='white')) +",param_choices[[.selectColor]]),
             "theme(axis.text.x=element_blank(), axis.ticks=element_blank(), axis.title.x=element_blank(),
       rect=element_blank(), line=element_blank(), axis.title.y=element_blank(),
-            plot.margin = unit(c(0,0,-0.5,0), 'lines'));",
-            sprintf("legends[[%i]] <- cowplot::get_legend(p%i + theme(legend.position='bottom', plot.margin = unit(c(0,0,0,0), 'lines')));", i, i))
+            plot.margin=unit(c(0,0,-0.5,0), 'lines'));",
+            sprintf("legends[[%i]] <- cowplot::get_legend(p%i + theme(legend.position='bottom', plot.margin=unit(c(0,0,0,0), 'lines')));", i, i))
     }
     annot_cmds <- unlist(annot_cmds)
 
@@ -200,9 +200,9 @@
       heatlegend, ncol=1, rel_heights=c(%s, %s))",
               paste0("p", c(seq_along(orderBy), 0),
                      c(rep(" + theme(legend.position='none')", length(orderBy)),
-                       " + theme(legend.position='none')"), collapse = ",\n        "),
+                       " + theme(legend.position='none')"), collapse=",\n        "),
               paste(c(rep(.heatMapRelHeightAnnot, length(orderBy)), .heatMapRelHeightHeatmap),
-                    collapse = ", "),
+                    collapse=", "),
               1-.heatMapRelHeightColorBar, .heatMapRelHeightColorBar)
     )
 
@@ -305,12 +305,12 @@
         col.vec <- assayColorMap(colormap, param_choices[[.heatMapAssay]], discrete=FALSE)(21L)
         col.add.before <- col.add.after <- break.add.before <- break.add.after <- ""
         if (param_choices[[.heatMapLower]] > min.obs && is.finite(param_choices[[.heatMapLower]])) {
-            col.add.before <- sprintf("c('%s',", col.vec[1])
-            break.add.before <- sprintf("c(%s,", min.obs)
+            col.add.before <- sprintf("c('%s', ", col.vec[1])
+            break.add.before <- sprintf("c(%s, ", min.obs)
         }
         if (param_choices[[.heatMapUpper]] < max.obs && is.finite(param_choices[[.heatMapUpper]])) {
-            col.add.after <- sprintf(",'%s')", col.vec[length(col.vec)])
-            break.add.after <- sprintf(",%s)", max.obs)
+            col.add.after <- sprintf(", '%s')", col.vec[length(col.vec)])
+            break.add.after <- sprintf(", %s)", max.obs)
         }
         if (col.add.before=="" && col.add.after != "") col.add.before <- "c("
         if (break.add.before=="" && break.add.after != "") break.add.before <- "c("
@@ -324,8 +324,8 @@
                             param_choices[[.heatMapAssay]],
                             col.add.after,
                             paste0("scales::rescale(", break.add.before,
-                                   "seq(", min(break.vec), ",", max(break.vec), ",length.out=21L)",
-                                   break.add.after, ", to=c(0,1), from=c(", paste0(limits, collapse=","), "))"),
+                                   "seq(", min(break.vec), ", ", max(break.vec), ", length.out=21L)",
+                                   break.add.after, ", to=c(0, 1), from=c(", paste0(limits, collapse=", "), "))"),
                             paste0(limits, collapse=","))
     }
     fill_cmd

--- a/R/iSEE-main.R
+++ b/R/iSEE-main.R
@@ -93,17 +93,16 @@
 #' library(scRNAseq)
 #'
 #' # Example data ----
-#' sce <- ReprocessedAllenData(assays = "tophat_counts")
+#' sce <- ReprocessedAllenData(assays="tophat_counts")
 #' class(sce)
 #'
 #' library(scater)
-#' counts(sce) <- assay(sce, "tophat_counts")
-#' sce <- normalize(sce)
+#' sce <- logNormCounts(sce, exprs_values="tophat_counts")
 #'
 #' sce <- runPCA(sce, ncomponents=4)
 #' sce <- runTSNE(sce)
-#' rowData(sce)$ave_count <- rowMeans(counts(sce))
-#' rowData(sce)$n_cells <- rowSums(counts(sce)>0)
+#' rowData(sce)$ave_count <- rowMeans(assay(sce, "tophat_counts"))
+#' rowData(sce)$n_cells <- rowSums(assay(sce, "tophat_counts") > 0)
 #' sce
 #'
 #' # launch the app itself ----

--- a/R/modes.R
+++ b/R/modes.R
@@ -22,19 +22,18 @@
 #'
 #' @examples
 #' library(scRNAseq)
+#'
 #' # Example data ----
-#' sce <- ReprocessedAllenData(assays = "tophat_counts")
+#' sce <- ReprocessedAllenData(assays="tophat_counts")
 #' class(sce)
 #'
 #' library(scater)
-#' counts(sce) <- assay(sce, "tophat_counts")
-#' sce <- normalize(sce)
-#'
+#' sce <- logNormCounts(sce, exprs_values="tophat_counts")
 #'
 #' # Select top variable genes ----
 #'
 #' plot_count <- 6
-#' rv <- rowVars(logcounts(sce))
+#' rv <- rowVars(assay(sce, "tophat_counts"))
 #' top_var <- head(order(rv, decreasing=TRUE), plot_count*2)
 #' top_var_genes <- rownames(sce)[top_var]
 #'

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -61,7 +61,7 @@ names(.all_aes_values) <- .all_aes_names
     data_cmds[["reducedDim"]] <- sprintf(
         "red.dim <- reducedDim(se, %i);", param_choices[[.redDimType]])
     data_cmds[["xy"]] <- sprintf(
-        "plot.data <- data.frame(X = red.dim[, %i], Y = red.dim[, %i], row.names=colnames(se));",
+        "plot.data <- data.frame(X=red.dim[, %i], Y=red.dim[, %i], row.names=colnames(se));",
         param_choices[[.redDimXAxis]], param_choices[[.redDimYAxis]])
 
     reddim_names <- names(.get_internal_info(se, field="red_dim_names"))
@@ -70,9 +70,9 @@ names(.all_aes_values) <- .all_aes_names
     x_lab <- sprintf("Dimension %s", param_choices[[.redDimXAxis]])
     y_lab <- sprintf("Dimension %s", param_choices[[.redDimYAxis]])
 
-    .plot_wrapper(data_cmds, param_choices = param_choices, all_memory = all_memory,
-        all_coordinates = all_coordinates, se = se, by_row = FALSE,
-        colormap = colormap, x_lab = x_lab, y_lab = y_lab, title = plot_title)
+    .plot_wrapper(data_cmds, param_choices=param_choices, all_memory=all_memory,
+        all_coordinates=all_coordinates, se=se, by_row=FALSE,
+        colormap=colormap, x_lab=x_lab, y_lab=y_lab, title=plot_title)
 }
 
 ############################################
@@ -113,18 +113,18 @@ names(.all_aes_values) <- .all_aes_names
     y_lab <- param_choices[[.colDataYAxis]]
     # NOTE: deparse() automatically adds quotes, AND protects against existing quotes/escapes.
     data_cmds[["y"]] <- sprintf(
-        "plot.data <- data.frame(Y = colData(se)[,%s], row.names=colnames(se));",
+        "plot.data <- data.frame(Y=colData(se)[, %s], row.names=colnames(se));",
         deparse(y_lab)
     )
 
     # Prepare X-axis data.
-    if (param_choices[[.colDataXAxis]]==.colDataXAxisNothingTitle) {
+    if (param_choices[[.colDataXAxis]] == .colDataXAxisNothingTitle) {
         x_lab <- ''
         data_cmds[["x"]] <- "plot.data$X <- factor(character(ncol(se)))"
     } else {
         x_lab <- param_choices[[.colDataXAxisColData]]
         data_cmds[["x"]] <- sprintf(
-            "plot.data$X <- colData(se)[,%s];",
+            "plot.data$X <- colData(se)[, %s];",
             deparse(x_lab)
         )
     }
@@ -133,9 +133,9 @@ names(.all_aes_values) <- .all_aes_names
     plot_title <- sprintf("%s %s", y_lab, x_title)
 
     .plot_wrapper(
-        data_cmds, param_choices = param_choices, all_memory = all_memory,
-        all_coordinates = all_coordinates, se = se, by_row = FALSE,
-        colormap = colormap, x_lab = x_lab, y_lab = y_lab, title = plot_title)
+        data_cmds, param_choices=param_choices, all_memory=all_memory,
+        all_coordinates=all_coordinates, se=se, by_row=FALSE,
+        colormap=colormap, x_lab=x_lab, y_lab=y_lab, title=plot_title)
 }
 
 ############################################
@@ -179,26 +179,26 @@ names(.all_aes_values) <- .all_aes_names
     gene_selected_y <- param_choices[[.featAssayYAxisFeatName]]
     assay_choice <- param_choices[[.featAssayAssay]]
     plot_title <- rownames(se)[gene_selected_y]
-    y_lab <- .feature_axis_label(se, gene_selected_y, assay_choice, multiline = FALSE)
+    y_lab <- .feature_axis_label(se, gene_selected_y, assay_choice, multiline=FALSE)
     data_cmds[["y"]] <- sprintf(
-        "plot.data <- data.frame(Y=assay(se, %i, withDimnames=FALSE)[%i,], row.names = colnames(se))",
+        "plot.data <- data.frame(Y=assay(se, %i, withDimnames=FALSE)[%i, ], row.names=colnames(se))",
         assay_choice, gene_selected_y
     )
 
     ## Checking X axis choice:
     x_choice <- param_choices[[.featAssayXAxis]]
 
-    if (x_choice==.featAssayXAxisColDataTitle) { # colData column selected
+    if (x_choice == .featAssayXAxisColDataTitle) { # colData column selected
         x_lab <- param_choices[[.featAssayXAxisColData]]
         plot_title <- paste(plot_title, "vs", x_lab)
-        data_cmds[["x"]] <- sprintf("plot.data$X <- colData(se)[,%s];", deparse(x_lab))
+        data_cmds[["x"]] <- sprintf("plot.data$X <- colData(se)[, %s];", deparse(x_lab))
 
-    } else if (x_choice==.featAssayXAxisFeatNameTitle) { # gene selected
+    } else if (x_choice == .featAssayXAxisFeatNameTitle) { # gene selected
         gene_selected_x <- param_choices[[.featAssayXAxisFeatName]]
         plot_title <- paste(plot_title, "vs", rownames(se)[gene_selected_x])
-        x_lab <- .feature_axis_label(se, gene_selected_x, assay_choice, multiline = FALSE)
+        x_lab <- .feature_axis_label(se, gene_selected_x, assay_choice, multiline=FALSE)
         data_cmds[["x"]] <- sprintf(
-            "plot.data$X <- assay(se, %i, withDimnames=FALSE)[%i,];",
+            "plot.data$X <- assay(se, %i, withDimnames=FALSE)[%i, ];",
             assay_choice, gene_selected_x
         )
 
@@ -208,9 +208,9 @@ names(.all_aes_values) <- .all_aes_names
     }
 
     .plot_wrapper(
-        data_cmds, param_choices = param_choices, all_memory = all_memory,
-        all_coordinates = all_coordinates, se = se, by_row = FALSE,
-        colormap = colormap, x_lab = x_lab, y_lab = y_lab, title = plot_title)
+        data_cmds, param_choices=param_choices, all_memory=all_memory,
+        all_coordinates=all_coordinates, se=se, by_row=FALSE,
+        colormap=colormap, x_lab=x_lab, y_lab=y_lab, title=plot_title)
 }
 
 ############################################
@@ -252,26 +252,26 @@ names(.all_aes_values) <- .all_aes_names
 
     # NOTE: deparse() automatically adds quotes, AND protects against existing quotes/escapes.
     data_cmds[["y"]] <- sprintf(
-        "plot.data <- data.frame(Y = rowData(se)[,%s], row.names=rownames(se));",
+        "plot.data <- data.frame(Y=rowData(se)[, %s], row.names=rownames(se));",
         deparse(y_lab)
     )
 
     # Prepare X-axis data.
-    if (param_choices[[.rowDataXAxis]]==.rowDataXAxisNothingTitle) {
+    if (param_choices[[.rowDataXAxis]] == .rowDataXAxisNothingTitle) {
         x_lab <- ''
         data_cmds[["x"]] <- "plot.data$X <- factor(character(nrow(se)))"
     } else {
         x_lab <- param_choices[[.rowDataXAxisRowData]]
-        data_cmds[["x"]] <- sprintf("plot.data$X <- rowData(se)[,%s];", deparse(x_lab))
+        data_cmds[["x"]] <- sprintf("plot.data$X <- rowData(se)[, %s];", deparse(x_lab))
     }
 
     x_title <- ifelse(x_lab == '', x_lab, sprintf("vs %s", x_lab))
     plot_title <- sprintf("%s %s", y_lab, x_title)
 
     .plot_wrapper(
-        data_cmds, param_choices = param_choices, all_memory = all_memory,
-        all_coordinates = all_coordinates, se = se, by_row = TRUE,
-        colormap = colormap, x_lab = x_lab, y_lab = y_lab, title = plot_title)
+        data_cmds, param_choices=param_choices, all_memory=all_memory,
+        all_coordinates=all_coordinates, se=se, by_row=TRUE,
+        colormap=colormap, x_lab=x_lab, y_lab=y_lab, title=plot_title)
 }
 
 ############################################
@@ -309,38 +309,38 @@ names(.all_aes_values) <- .all_aes_names
     assay_choice <- param_choices[[.sampAssayAssay]]
 
     plot_title <- colnames(se)[samp_selected_y]
-    y_lab <- .sample_axis_label(se, samp_selected_y, assay_choice, multiline = FALSE)
+    y_lab <- .sample_axis_label(se, samp_selected_y, assay_choice, multiline=FALSE)
     data_cmds[["y"]] <- sprintf(
-        "plot.data <- data.frame(Y=assay(se, %i, withDimnames=FALSE)[,%i], row.names = rownames(se));",
+        "plot.data <- data.frame(Y=assay(se, %i, withDimnames=FALSE)[,%i], row.names=rownames(se));",
         assay_choice, samp_selected_y
     )
 
     # Prepare X-axis data.
     x_choice <- param_choices[[.sampAssayXAxis]]
 
-    if (x_choice==.sampAssayXAxisNothingTitle) {
+    if (x_choice == .sampAssayXAxisNothingTitle) {
         x_lab <- ''
         data_cmds[["x"]] <- "plot.data$X <- factor(character(nrow(se)));"
 
-    } else if (x_choice==.sampAssayXAxisRowDataTitle) {
+    } else if (x_choice == .sampAssayXAxisRowDataTitle) {
         x_lab <- param_choices[[.sampAssayXAxisRowData]]
         plot_title <- paste(plot_title, "vs", x_lab)
-        data_cmds[["x"]] <- sprintf("plot.data$X <- rowData(se)[,%s];", deparse(x_lab))
+        data_cmds[["x"]] <- sprintf("plot.data$X <- rowData(se)[, %s];", deparse(x_lab))
 
     } else {
         samp_selected_x <- param_choices[[.sampAssayXAxisSampName]]
         plot_title <- paste(plot_title, "vs", colnames(se)[samp_selected_x])
-        x_lab <- .sample_axis_label(se, samp_selected_x, assay_choice, multiline = FALSE)
+        x_lab <- .sample_axis_label(se, samp_selected_x, assay_choice, multiline=FALSE)
         data_cmds[["x"]] <- sprintf(
-            "plot.data$X <- assay(se, %i, withDimnames=FALSE)[,%i];",
+            "plot.data$X <- assay(se, %i, withDimnames=FALSE)[, %i];",
             assay_choice, samp_selected_x
         )
     }
 
     .plot_wrapper(
-        data_cmds, param_choices = param_choices, all_memory = all_memory,
-        all_coordinates = all_coordinates, se = se, by_row = TRUE,
-        colormap = colormap, x_lab = x_lab, y_lab = y_lab, title = plot_title)
+        data_cmds, param_choices=param_choices, all_memory=all_memory,
+        all_coordinates=all_coordinates, se=se, by_row=TRUE,
+        colormap=colormap, x_lab=x_lab, y_lab=y_lab, title=plot_title)
 }
 
 ############################################
@@ -385,15 +385,15 @@ names(.all_aes_values) <- .all_aes_names
 #' \code{\link{.downsample_points}},
 #' \code{\link{.create_plot}}
 .plot_wrapper <- function(data_cmds, param_choices, all_memory, all_coordinates, se, by_row, ...) {
-    setup_out <- .extract_plotting_data(data_cmds, param_choices, all_memory, all_coordinates, se, by_row = by_row)
+    setup_out <- .extract_plotting_data(data_cmds, param_choices, all_memory, all_coordinates, se, by_row=by_row)
 
     xy <- setup_out$envir$plot.data # DO NOT MOVE below .downsample_points, as downsampling will alter the value in 'envir'.
 
     downsample_cmds <- .downsample_points(param_choices, setup_out$envir)
 
-    plot_out <- .create_plot(setup_out$envir, param_choices, ..., color_lab = setup_out$color_lab, shape_lab = setup_out$shape_lab, size_lab = setup_out$size_lab, by_row = by_row)
+    plot_out <- .create_plot(setup_out$envir, param_choices, ..., color_lab=setup_out$color_lab, shape_lab=setup_out$shape_lab, size_lab=setup_out$size_lab, by_row=by_row)
 
-    return(list(cmd_list = c(setup_out$cmd_list, list(plot=c(downsample_cmds, plot_out$cmds))), xy = xy, plot = plot_out$plot))
+    return(list(cmd_list=c(setup_out$cmd_list, list(plot=c(downsample_cmds, plot_out$cmds))), xy=xy, plot=plot_out$plot))
 }
 
 ############################################
@@ -509,7 +509,7 @@ names(.all_aes_values) <- .all_aes_names
 
     # Removing NAs as they mess up .process_selectby_choice.
     clean_fields <- c("X", "Y", names(facet_out))
-    clean_expression <- paste(sprintf("!is.na(%s)", clean_fields), collapse = " & ")
+    clean_expression <- paste(sprintf("!is.na(%s)", clean_fields), collapse=" & ")
     more_data_cmds <- .add_command(more_data_cmds, sprintf("plot.data <- subset(plot.data, %s);", clean_expression), name='na.rm')
 
     more_data_cmds <- .evaluate_commands(more_data_cmds, eval_env)
@@ -612,10 +612,10 @@ names(.all_aes_values) <- .all_aes_names
         ytype <- "Y"
 
         plot_type <- envir$plot.type
-        if (plot_type=="square") {
+        if (plot_type == "square") {
             xtype <- "jitteredX"
             ytype <- "jitteredY"
-        } else if (plot_type=="violin" || plot_type=="violin_horizontal") {
+        } else if (plot_type == "violin" || plot_type == "violin_horizontal") {
             xtype <- "jitteredX"
         }
 
@@ -699,13 +699,13 @@ names(.all_aes_values) <- .all_aes_names
 
     # Dispatch to different plotting commands, depending on X/Y being groupable
     extra_cmds <- c(extra_cmds, switch(plot_type,
-        square = .square_plot(plot_data=plot_data, param_choices=param_choices,
+        square=.square_plot(plot_data=plot_data, param_choices=param_choices,
             is_subsetted=is_subsetted, ...),
-        violin = .violin_plot(plot_data=plot_data, param_choices=param_choices,
+        violin=.violin_plot(plot_data=plot_data, param_choices=param_choices,
             is_subsetted=is_subsetted, is_downsampled=is_downsampled, ...),
-        violin_horizontal = .violin_plot(plot_data=plot_data, param_choices=param_choices,
+        violin_horizontal=.violin_plot(plot_data=plot_data, param_choices=param_choices,
             is_subsetted=is_subsetted, is_downsampled=is_downsampled, ..., horizontal=TRUE),
-        scatter = .scatter_plot(plot_data=plot_data, param_choices=param_choices,
+        scatter=.scatter_plot(plot_data=plot_data, param_choices=param_choices,
             is_subsetted=is_subsetted, is_downsampled=is_downsampled, ...)
     ))
 
@@ -740,7 +740,7 @@ names(.all_aes_values) <- .all_aes_names
 
     # Evaluating the plotting commands.
     plot_out <- .text_eval(extra_cmds, envir)
-    return(list(cmds = extra_cmds, plot = plot_out))
+    return(list(cmds=extra_cmds, plot=plot_out))
 }
 
 ############################################
@@ -784,7 +784,7 @@ names(.all_aes_values) <- .all_aes_names
 #' \code{\link{.create_plot}}
 #'
 #' @importFrom ggplot2 ggplot coord_cartesian theme_bw theme element_text
-.scatter_plot <- function(plot_data, param_choices, x_lab, y_lab, color_lab, shape_lab, size_lab, title, by_row = FALSE, is_subsetted = FALSE, is_downsampled = FALSE) {
+.scatter_plot <- function(plot_data, param_choices, x_lab, y_lab, color_lab, shape_lab, size_lab, title, by_row=FALSE, is_subsetted=FALSE, is_downsampled=FALSE) {
     plot_cmds <- list()
     plot_cmds[["ggplot"]] <- "ggplot() +"
 
@@ -792,7 +792,7 @@ names(.all_aes_values) <- .all_aes_names
     color_set <- !is.null(plot_data$ColorBy)
     shape_set <- param_choices[[.shapeByField]] != .shapeByNothingTitle
     size_set <- param_choices[[.sizeByField]] != .sizeByNothingTitle
-    new_aes <- .build_aes(color = color_set, shape = shape_set, size = size_set)
+    new_aes <- .build_aes(color=color_set, shape=shape_set, size=size_set)
     plot_cmds[["points"]] <- .create_points(param_choices, !is.null(plot_data$SelectBy), new_aes, color_set, size_set)
 
     # Defining the color commands.
@@ -803,36 +803,36 @@ names(.all_aes_values) <- .all_aes_names
     }
 
     # Adding axes labels.
-    plot_cmds[["labs"]] <- .build_labs(x = x_lab, y = y_lab, color = color_lab, shape = shape_lab, size = size_lab, title = title)
+    plot_cmds[["labs"]] <- .build_labs(x=x_lab, y=y_lab, color=color_lab, shape=shape_lab, size=size_lab, title=title)
 
     # Defining boundaries if zoomed.
     bounds <- param_choices[[.zoomData]][[1]]
     if (!is.null(bounds)) {
         plot_cmds[["coord"]] <- sprintf(
-            "coord_cartesian(xlim = c(%s, %s), ylim = c(%s, %s), expand = FALSE) +", # FALSE, to get a literal zoom.
+            "coord_cartesian(xlim=c(%s, %s), ylim=c(%s, %s), expand=FALSE) +", # FALSE, to get a literal zoom.
             deparse(bounds["xmin"]), deparse(bounds["xmax"]),
             deparse(bounds["ymin"]),  deparse(bounds["ymax"])
         )
     } else {
         full_data <- ifelse(is_subsetted, "plot.data.all", ifelse(is_downsampled, "plot.data.pre", "plot.data"))
-        plot_cmds[["coord"]] <- sprintf("coord_cartesian(xlim = range(%s$X, na.rm = TRUE),
-    ylim = range(%s$Y, na.rm = TRUE), expand = TRUE) +", full_data, full_data)
+        plot_cmds[["coord"]] <- sprintf("coord_cartesian(xlim=range(%s$X, na.rm=TRUE),
+    ylim=range(%s$Y, na.rm=TRUE), expand=TRUE) +", full_data, full_data)
     }
 
     if (param_choices[[.contourAddTitle]]) {
-        plot_cmds[["contours"]] <- sprintf("geom_density_2d(aes(x = X, y = Y), plot.data, colour='%s') +", param_choices[[.contourColor]])
+        plot_cmds[["contours"]] <- sprintf("geom_density_2d(aes(x=X, y=Y), plot.data, colour='%s') +", param_choices[[.contourColor]])
     }
 
     # Retain axes when no points are present.
-    if (nrow(plot_data)==0 && is_subsetted) {
-        plot_cmds[["select_blank"]] <- "geom_blank(data = plot.data.all, inherit.aes = FALSE, aes(x = X, y = Y)) +"
+    if (nrow(plot_data) == 0 && is_subsetted) {
+        plot_cmds[["select_blank"]] <- "geom_blank(data=plot.data.all, inherit.aes=FALSE, aes(x=X, y=Y)) +"
     }
 
     # Adding further aesthetic elements.
     plot_cmds[["scale_color"]] <- color_scale_cmd
     plot_cmds[["theme_base"]] <- "theme_bw() +"
     plot_cmds[["theme_custom"]] <- sprintf(
-        "theme(legend.position = '%s', legend.box = 'vertical', legend.text=element_text(size=%s), legend.title=element_text(size=%s),
+        "theme(legend.position='%s', legend.box='vertical', legend.text=element_text(size=%s), legend.title=element_text(size=%s),
         axis.text=element_text(size=%s), axis.title=element_text(size=%s), title=element_text(size=%s))",
         tolower(param_choices[[.plotLegendPosition]]),
         param_choices[[.plotFontSize]]*.plotFontSizeLegendTextDefault,
@@ -905,13 +905,13 @@ names(.all_aes_values) <- .all_aes_names
 #' coord_flip scale_x_discrete scale_y_discrete
 .violin_plot <- function(
     plot_data, param_choices, x_lab, y_lab, color_lab, shape_lab, size_lab, title,
-    horizontal = FALSE, by_row = FALSE, is_subsetted = FALSE, is_downsampled = FALSE) {
+    horizontal=FALSE, by_row=FALSE, is_subsetted=FALSE, is_downsampled=FALSE) {
 
     plot_cmds <- list()
     plot_cmds[["ggplot"]] <- "ggplot() +" # do NOT put aes here, it does not play nice with shiny brushes.
     plot_cmds[["violin"]] <- sprintf(
-        "geom_violin(%s, alpha = 0.2, data=%s, scale = 'width', width = 0.8) +",
-        .build_aes(color = FALSE, group = TRUE),
+        "geom_violin(%s, alpha=0.2, data=%s, scale='width', width=0.8) +",
+        .build_aes(color=FALSE, group=TRUE),
         ifelse(is_downsampled, "plot.data.pre", "plot.data")
     )
 
@@ -919,7 +919,7 @@ names(.all_aes_values) <- .all_aes_names
     color_set <- !is.null(plot_data$ColorBy)
     shape_set <- param_choices[[.shapeByField]] != .shapeByNothingTitle
     size_set <- param_choices[[.sizeByField]] != .sizeByNothingTitle
-    new_aes <- .build_aes(color = color_set, shape = shape_set, size=size_set, alt=c(x="jitteredX"))
+    new_aes <- .build_aes(color=color_set, shape=shape_set, size=size_set, alt=c(x="jitteredX"))
     plot_cmds[["points"]] <- .create_points(param_choices, !is.null(plot_data$SelectBy), new_aes, color_set, size_set)
 
     # Defining the color commands.
@@ -936,7 +936,7 @@ names(.all_aes_values) <- .all_aes_names
         x_lab <- tmp
     }
 
-    plot_cmds[["labs"]] <- .build_labs(x = x_lab, y = y_lab, color = color_lab, shape = shape_lab, size = size_lab, title = title)
+    plot_cmds[["labs"]] <- .build_labs(x=x_lab, y=y_lab, color=color_lab, shape=shape_lab, size=size_lab, title=title)
 
     # Defining boundaries if zoomed. This requires some finesse to deal with horizontal plots,
     # where the point selection is computed on the flipped coordinates.
@@ -956,12 +956,12 @@ names(.all_aes_values) <- .all_aes_names
         bounds["xmax"] <- floor(bounds["xmax"]) + 0.5
 
         plot_cmds[["coord"]] <- sprintf(
-            "%s(xlim = c(%s, %s), ylim = c(%s, %s), expand = FALSE) +", # FALSE, to get a literal zoom.
+            "%s(xlim=c(%s, %s), ylim=c(%s, %s), expand=FALSE) +", # FALSE, to get a literal zoom.
             coord_cmd, deparse(bounds["xmin"]), deparse(bounds["xmax"]),
             deparse(bounds["ymin"]), deparse(bounds["ymax"])
         )
     } else {
-        plot_cmds[["coord"]] <- sprintf("%s(ylim = range(%s$Y, na.rm=TRUE), expand = TRUE) +",
+        plot_cmds[["coord"]] <- sprintf("%s(ylim=range(%s$Y, na.rm=TRUE), expand=TRUE) +",
             coord_cmd, ifelse(is_subsetted, "plot.data.all", ifelse(is_downsampled, "plot.data.pre", "plot.data"))
         )
     }
@@ -969,28 +969,28 @@ names(.all_aes_values) <- .all_aes_names
     plot_cmds[["scale_color"]] <- color_scale_cmd
 
     # Retain axes when no points are generated.
-    if (nrow(plot_data)==0 && is_subsetted) {
-        plot_cmds[["select_blank"]] <- "geom_blank(data = plot.data.all, inherit.aes = FALSE, aes(x = X, y = Y)) +"
+    if (nrow(plot_data) == 0 && is_subsetted) {
+        plot_cmds[["select_blank"]] <- "geom_blank(data=plot.data.all, inherit.aes=FALSE, aes(x=X, y=Y)) +"
     }
 
     # Preserving the x-axis range when no zoom is applied.
     # This applies even for horizontal violin plots, as this command is executed internally before coord_flip().
-    scale_x_cmd <- "scale_x_discrete(drop = FALSE%s) +"
+    scale_x_cmd <- "scale_x_discrete(drop=FALSE%s) +"
     if (is.null(bounds)) {
         scale_x_extra <- ""
     } else {
         # Restrict axis ticks to visible levels
         scale_x_extra <- sprintf(
-            ", breaks = levels(plot.data$X)[%i:%i]",
+            ", breaks=levels(plot.data$X)[%i:%i]",
             ceiling(bounds["xmin"]), floor(bounds["xmax"]))
     }
      plot_cmds[["scale_x"]] <- sprintf(scale_x_cmd, scale_x_extra)
 
     plot_cmds[["theme_base"]] <- "theme_bw() +"
     plot_cmds[["theme_custom"]] <- sprintf(
-        "theme(legend.position = '%s', legend.text=element_text(size=%s),
-        legend.title=element_text(size=%s), legend.box = 'vertical',
-        axis.text.x = element_text(angle=90, size=%s, hjust=1, vjust=0.5),
+        "theme(legend.position='%s', legend.text=element_text(size=%s),
+        legend.title=element_text(size=%s), legend.box='vertical',
+        axis.text.x=element_text(angle=90, size=%s, hjust=1, vjust=0.5),
         axis.text.y=element_text(size=%s),
         axis.title=element_text(size=%s), title=element_text(size=%s))",
         tolower(param_choices[[.plotLegendPosition]]),
@@ -1092,18 +1092,18 @@ plot.data$Y <- tmp;")
 #'
 #' @importFrom ggplot2 ggplot geom_tile coord_cartesian theme_bw theme
 #' scale_x_discrete scale_y_discrete guides
-.square_plot <- function(plot_data, param_choices, se, x_lab, y_lab, color_lab, shape_lab, size_lab, title, by_row = FALSE, is_subsetted = FALSE) {
+.square_plot <- function(plot_data, param_choices, se, x_lab, y_lab, color_lab, shape_lab, size_lab, title, by_row=FALSE, is_subsetted=FALSE) {
     plot_cmds <- list()
     plot_cmds[["ggplot"]] <- "ggplot(plot.data) +"
     plot_cmds[["tile"]] <-
-"geom_tile(aes(x = X, y = Y, height = 2*YWidth, width = 2*XWidth, group = interaction(X, Y)),
-    summary.data, color = 'black', alpha = 0, size = 0.5) +"
+"geom_tile(aes(x=X, y=Y, height=2*YWidth, width=2*XWidth, group=interaction(X, Y)),
+    summary.data, color='black', alpha=0, size=0.5) +"
 
     # Adding the points to the plot (with/without point selection).
     color_set <- !is.null(plot_data$ColorBy)
     shape_set <- param_choices[[.shapeByField]] != .shapeByNothingTitle
     size_set <- param_choices[[.sizeByField]] != .sizeByNothingTitle
-    new_aes <- .build_aes(color = color_set, shape = shape_set, size = size_set, alt=c(x="jitteredX", y="jitteredY"))
+    new_aes <- .build_aes(color=color_set, shape=shape_set, size=size_set, alt=c(x="jitteredX", y="jitteredY"))
     plot_cmds[["points"]] <- .create_points(param_choices, !is.null(plot_data$SelectBy), new_aes, color_set, size_set)
 
     # Defining the color commands.
@@ -1118,7 +1118,7 @@ plot.data$Y <- tmp;")
     plot_cmds[["scale_color"]] <- color_scale_cmd
 
     # Creating labels.
-    plot_cmds[["labs"]] <- .build_labs(x = x_lab, y = y_lab, color = color_lab, shape = shape_lab, size = size_lab, title = title)
+    plot_cmds[["labs"]] <- .build_labs(x=x_lab, y=y_lab, color=color_lab, shape=shape_lab, size=size_lab, title=title)
 
     # Defining boundaries if zoomed.
     bounds <- param_choices[[.zoomData]][[1]]
@@ -1131,40 +1131,40 @@ plot.data$Y <- tmp;")
         bounds["ymax"] <- floor(bounds["ymax"]) + 0.5
 
         plot_cmds[["coord"]] <- sprintf(
-            "coord_cartesian(xlim = c(%s, %s), ylim = c(%s, %s), expand = FALSE) +",
+            "coord_cartesian(xlim=c(%s, %s), ylim=c(%s, %s), expand=FALSE) +",
             deparse(bounds["xmin"]), deparse(bounds["xmax"]),
             deparse(bounds["ymin"]), deparse(bounds["ymax"])
         )
     }
 
-    scale_x_cmd <- "scale_x_discrete(drop = FALSE%s) +"
-    scale_y_cmd <- "scale_y_discrete(drop = FALSE%s) +"
+    scale_x_cmd <- "scale_x_discrete(drop=FALSE%s) +"
+    scale_y_cmd <- "scale_y_discrete(drop=FALSE%s) +"
     if (is.null(bounds)) {
         scale_x_extra <- ""
         scale_y_extra <- ""
     } else {
         # Restrict axis ticks to visible levels
         scale_x_extra <- sprintf(
-            ", breaks = levels(plot.data$X)[%i:%i]",
+            ", breaks=levels(plot.data$X)[%i:%i]",
             ceiling(bounds["xmin"]), floor(bounds["xmax"]))
         scale_y_extra <- sprintf(
-            ", breaks = levels(plot.data$Y)[%i:%i]",
+            ", breaks=levels(plot.data$Y)[%i:%i]",
             ceiling(bounds["ymin"]), floor(bounds["ymax"]))
     }
      plot_cmds[["scale_x"]] <- sprintf(scale_x_cmd, scale_x_extra)
      plot_cmds[["scale_y"]] <- sprintf(scale_y_cmd, scale_y_extra)
 
     # Retain axes when no points are present.
-    if (nrow(plot_data)==0 && is_subsetted) {
-        plot_cmds[["select_blank"]] <- "geom_blank(data = plot.data.all, inherit.aes = FALSE, aes(x = X, y = Y)) +"
+    if (nrow(plot_data) == 0 && is_subsetted) {
+        plot_cmds[["select_blank"]] <- "geom_blank(data=plot.data.all, inherit.aes=FALSE, aes(x=X, y=Y)) +"
     }
 
     # Do not display the size legend (saves plot space, as well)
     plot_cmds[["theme_base"]] <- "theme_bw() +"
-    plot_cmds[["theme_custom"]] <- sprintf("theme(legend.position = '%s', legend.text=element_text(size=%s),
-    legend.title=element_text(size=%s), legend.box = 'vertical',
-    axis.text.x = element_text(angle=90, size=%s, hjust=1, vjust=0.5),
-    axis.text.y = element_text(size=%s),
+    plot_cmds[["theme_custom"]] <- sprintf("theme(legend.position='%s', legend.text=element_text(size=%s),
+    legend.title=element_text(size=%s), legend.box='vertical',
+    axis.text.x=element_text(angle=90, size=%s, hjust=1, vjust=0.5),
+    axis.text.y=element_text(size=%s),
     axis.title=element_text(size=%s), title=element_text(size=%s))",
         tolower(param_choices[[.plotLegendPosition]]),
         param_choices[[.plotFontSize]]*.plotFontSizeLegendTextDefault,
@@ -1238,20 +1238,20 @@ plot.data$jitteredY <- j.out$Y;", groupvar)
 .define_colorby_for_column_plot <- function(param_choices, se) {
     color_choice <- param_choices[[.colorByField]]
 
-    if (color_choice==.colorByColDataTitle) {
+    if (color_choice == .colorByColDataTitle) {
         covariate_name <- param_choices[[.colorByColData]]
         return(list(label=covariate_name,
-            cmds=sprintf("plot.data$ColorBy <- colData(se)[,%s];", deparse(covariate_name))))
+            cmds=sprintf("plot.data$ColorBy <- colData(se)[, %s];", deparse(covariate_name))))
 
-    } else if (color_choice==.colorByFeatNameTitle) {
+    } else if (color_choice == .colorByFeatNameTitle) {
         # Set the color to the selected gene
         chosen_gene <- param_choices[[.colorByFeatName]]
         assay_choice <- param_choices[[.colorByFeatNameAssay]]
         return(list(
-            label=.feature_axis_label(se, chosen_gene, assay_choice, multiline = TRUE),
-            cmds=sprintf("plot.data$ColorBy <- assay(se, %i, withDimnames=FALSE)[%i,];", assay_choice, chosen_gene)))
+            label=.feature_axis_label(se, chosen_gene, assay_choice, multiline=TRUE),
+            cmds=sprintf("plot.data$ColorBy <- assay(se, %i, withDimnames=FALSE)[%i, ];", assay_choice, chosen_gene)))
 
-    } else if (color_choice==.colorBySampNameTitle) {
+    } else if (color_choice == .colorBySampNameTitle) {
         chosen_sample <- param_choices[[.colorBySampName]]
         return(list(
             label=.sample_axis_label(se, chosen_sample, assay_id=NULL),
@@ -1267,25 +1267,25 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_sample))))
 .define_colorby_for_row_plot <- function(param_choices, se) {
     color_choice <- param_choices[[.colorByField]]
 
-    if (color_choice==.colorByRowDataTitle) {
+    if (color_choice == .colorByRowDataTitle) {
         covariate_name <- param_choices[[.colorByRowData]]
         return(list(
             label=covariate_name,
-            cmds=sprintf("plot.data$ColorBy <- rowData(se)[,%s];", deparse(covariate_name))))
+            cmds=sprintf("plot.data$ColorBy <- rowData(se)[, %s];", deparse(covariate_name))))
 
-    } else if (color_choice==.colorByFeatNameTitle) {
+    } else if (color_choice == .colorByFeatNameTitle) {
         chosen_gene <- param_choices[[.colorByFeatName]]
         return(list(
             label=.feature_axis_label(se, chosen_gene, assay_id=NULL),
             cmds=sprintf("plot.data$ColorBy <- logical(nrow(plot.data));
 plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
 
-    } else if (color_choice==.colorBySampNameTitle) {
+    } else if (color_choice == .colorBySampNameTitle) {
         chosen_sample <- param_choices[[.colorBySampName]]
         assay_choice <- param_choices[[.colorBySampNameAssay]]
         return(list(
-            label=.sample_axis_label(se, chosen_sample, assay_choice, multiline = TRUE),
-            cmds=sprintf("plot.data$ColorBy <- assay(se, %i, withDimnames=FALSE)[,%i];", assay_choice, chosen_sample)))
+            label=.sample_axis_label(se, chosen_sample, assay_choice, multiline=TRUE),
+            cmds=sprintf("plot.data$ColorBy <- assay(se, %i, withDimnames=FALSE)[, %i];", assay_choice, chosen_sample)))
 
     } else {
         return(NULL)
@@ -1334,15 +1334,15 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
 
     # This slightly duplicates the work in .define_colorby_for_row_plot(),
     # but this is necessary to separate the function of data acquisition and plot generation.
-    if (color_choice==.colorByColDataTitle) {
+    if (color_choice == .colorByColDataTitle) {
         covariate_name <- param_choices[[.colorByColData]]
         cmds <- .create_color_scale("colDataColorMap", deparse(covariate_name), colorby)
 
-    } else if (color_choice==.colorByFeatNameTitle) {
+    } else if (color_choice == .colorByFeatNameTitle) {
         assay_choice <- param_choices[[.colorByFeatNameAssay]]
         cmds <- .create_color_scale("assayColorMap", deparse(assay_choice), colorby)
 
-    } else if (color_choice==.colorBySampNameTitle) {
+    } else if (color_choice == .colorBySampNameTitle) {
         col_choice <- param_choices[[.colorBySampNameColor]]
         cmds <- c(
             sprintf(
@@ -1372,11 +1372,11 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
 
     # This slightly duplicates the work in .define_colorby_for_row_plot(),
     # but this is necessary to separate the function of data acquisition and plot generation.
-    if (color_choice==.colorByRowDataTitle) {
+    if (color_choice == .colorByRowDataTitle) {
         covariate_name <- param_choices[[.colorByRowData]]
         cmds <- .create_color_scale("rowDataColorMap", deparse(covariate_name), colorby)
 
-    } else if (color_choice==.colorByFeatNameTitle) {
+    } else if (color_choice == .colorByFeatNameTitle) {
         col_choice <- param_choices[[.colorByFeatNameColor]]
         cmds <- c(
             sprintf(
@@ -1390,7 +1390,7 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
                        ""))
         )
 
-    } else if (color_choice==.colorBySampNameTitle) {
+    } else if (color_choice == .colorBySampNameTitle) {
         assay_choice <- param_choices[[.colorBySampNameAssay]]
         cmds <- .create_color_scale("assayColorMap", deparse(assay_choice), colorby)
     }
@@ -1493,10 +1493,10 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
 .define_shapeby_for_column_plot <- function(param_choices, se) {
     shape_choice <- param_choices[[.shapeByField]]
 
-    if (shape_choice==.shapeByColDataTitle) {
+    if (shape_choice == .shapeByColDataTitle) {
         covariate_name <- param_choices[[.shapeByColData]]
         return(list(label=covariate_name,
-            cmds=sprintf("plot.data$ShapeBy <- colData(se)[,%s];", deparse(covariate_name))))
+            cmds=sprintf("plot.data$ShapeBy <- colData(se)[, %s];", deparse(covariate_name))))
 
     } else {
         return(NULL)
@@ -1507,10 +1507,10 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
 .define_shapeby_for_row_plot <- function(param_choices, se) {
     shape_choice <- param_choices[[.shapeByField]]
 
-    if (shape_choice==.shapeByRowDataTitle) {
+    if (shape_choice == .shapeByRowDataTitle) {
         covariate_name <- param_choices[[.shapeByRowData]]
         return(list(label=covariate_name,
-            cmds=sprintf("plot.data$ShapeBy <- rowData(se)[,%s];", deparse(covariate_name))))
+            cmds=sprintf("plot.data$ShapeBy <- rowData(se)[, %s];", deparse(covariate_name))))
 
     } else {
         return(NULL)
@@ -1550,10 +1550,10 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
 .define_sizeby_for_column_plot <- function(param_choices, se) {
     size_choice <- param_choices[[.sizeByField]]
 
-    if (size_choice==.sizeByColDataTitle) {
+    if (size_choice == .sizeByColDataTitle) {
         covariate_name <- param_choices[[.sizeByColData]]
         return(list(label=covariate_name,
-                    cmds=sprintf("plot.data$SizeBy <- colData(se)[,%s];", deparse(covariate_name))))
+                    cmds=sprintf("plot.data$SizeBy <- colData(se)[, %s];", deparse(covariate_name))))
 
     } else {
         return(NULL)
@@ -1564,10 +1564,10 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
 .define_sizeby_for_row_plot <- function(param_choices, se) {
     size_choice <- param_choices[[.sizeByField]]
 
-    if (size_choice==.sizeByRowDataTitle) {
+    if (size_choice == .sizeByRowDataTitle) {
         covariate_name <- param_choices[[.sizeByRowData]]
         return(list(label=covariate_name,
-                    cmds=sprintf("plot.data$SizeBy <- rowData(se)[,%s];", deparse(covariate_name))))
+                    cmds=sprintf("plot.data$SizeBy <- rowData(se)[, %s];", deparse(covariate_name))))
 
     } else {
         return(NULL)
@@ -1640,14 +1640,14 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
 
         transmit_type_param <- all_memory[[select_by$Type]]
 
-        cur_choice <- param_choices[,.selectMultiType]
-        if (cur_choice==.selectMultiUnionTitle) {
-            select_sources <- c(NA_integer_, seq_along(transmit_type_param[,.multiSelectHistory][[1]]))
-        } else if (cur_choice==.selectMultiActiveTitle) {
+        cur_choice <- param_choices[, .selectMultiType]
+        if (cur_choice == .selectMultiUnionTitle) {
+            select_sources <- c(NA_integer_, seq_along(transmit_type_param[, .multiSelectHistory][[1]]))
+        } else if (cur_choice == .selectMultiActiveTitle) {
             select_sources <- NA_integer_
         } else {
-            select_sources <- param_choices[,.selectMultiSaved]
-            if (select_sources==0L) {
+            select_sources <- param_choices[, .selectMultiSaved]
+            if (select_sources == 0L) {
                 # '0' selection in memory means no selection.
                 select_sources <- integer(0)
             }
@@ -1656,14 +1656,14 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
         starting <- TRUE
         for (i in select_sources) {
             if (is.na(i)) {
-                brush_val <- transmit_type_param[,.brushData][[select_by$ID]]
-                lasso_val <- transmit_type_param[,.lassoData][[select_by$ID]]
+                brush_val <- transmit_type_param[, .brushData][[select_by$ID]]
+                lasso_val <- transmit_type_param[, .lassoData][[select_by$ID]]
                 brush_src <- sprintf("all_brushes[['%s']]", transmitter)
                 lasso_src <- sprintf("all_lassos[['%s']]", transmitter)
                 use_brush <- !is.null(brush_val)
                 use_lasso <- !is.null(lasso_val) && lasso_val$closed
             } else {
-                all_histories <- transmit_type_param[,.multiSelectHistory][[select_by$ID]]
+                all_histories <- transmit_type_param[, .multiSelectHistory][[select_by$ID]]
                 brush_val <- lasso_val <- all_histories[[i]]
                 brush_src <- lasso_src <- sprintf("all_select_histories[['%s']][[%i]]", transmitter, i)
 
@@ -1692,7 +1692,7 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
         if (length(cmds)) {
             cmds[["select"]] <- "plot.data$SelectBy <- rownames(plot.data) %in% selected_pts;"
 
-            if (param_choices[[.selectEffect]]==.selectRestrictTitle) {
+            if (param_choices[[.selectEffect]] == .selectRestrictTitle) {
                 cmds[["saved"]] <- "plot.data.all <- plot.data;"
                 cmds[["subset"]] <- "plot.data <- subset(plot.data, SelectBy);"
             }
@@ -1723,9 +1723,9 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
 #' \code{\link{.self_brush_box}},
 #' \code{\link{.self_lasso_path}}
 .populate_selection_environment <- function(param_choices, envir) {
-    envir$all_brushes <- list(param_choices[,.brushData][[1]])
-    envir$all_lassos <- list(param_choices[,.lassoData][[1]])
-    envir$all_select_histories <- list(param_choices[,.multiSelectHistory][[1]])
+    envir$all_brushes <- list(param_choices[, .brushData][[1]])
+    envir$all_lassos <- list(param_choices[, .lassoData][[1]])
+    envir$all_select_histories <- list(param_choices[, .multiSelectHistory][[1]])
     names(envir$all_brushes) <- names(envir$all_lassos) <- names(envir$all_select_histories) <- rownames(param_choices)
     invisible(NULL)
 }
@@ -1797,7 +1797,7 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
 
     if (selected) {
         select_effect <- param_choices[[.selectEffect]]
-        if (select_effect==.selectColorTitle) {
+        if (select_effect == .selectColorTitle) {
             plot_cmds[["select_other"]] <- sprintf(
                 "geom_point(%s, alpha=%s, data=subset(plot.data, !SelectBy)%s%s) +",
                 aes, param_choices[[.plotPointAlpha]], default_color,
@@ -1811,9 +1811,9 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
                 # param_choices[[.plotPointSize]]
             )
         }
-        if (select_effect==.selectTransTitle) {
+        if (select_effect == .selectTransTitle) {
             plot_cmds[["select_other"]] <- sprintf(
-                "geom_point(%s, subset(plot.data, !SelectBy), alpha = %.2f%s%s) +",
+                "geom_point(%s, subset(plot.data, !SelectBy), alpha=%.2f%s%s) +",
                 aes, param_choices[[.selectTransAlpha]], default_color,
                 common_size
                 # param_choices[[.plotPointSize]]
@@ -1824,9 +1824,9 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
                 # param_choices[[.plotPointSize]]
             )
         }
-        if (select_effect==.selectRestrictTitle) {
+        if (select_effect == .selectRestrictTitle) {
             plot_cmds[["select_restrict"]] <- sprintf(
-                "geom_point(%s, alpha = %s, plot.data%s%s) +",
+                "geom_point(%s, alpha=%s, plot.data%s%s) +",
                 aes, param_choices[[.plotPointAlpha]], default_color,
                 common_size
                 # param_choices[[.plotPointSize]]
@@ -1834,7 +1834,7 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
         }
     } else {
         plot_cmds[["point"]] <- sprintf(
-            "geom_point(%s, alpha = %s, plot.data%s%s) +",
+            "geom_point(%s, alpha=%s, plot.data%s%s) +",
             aes, param_choices[[.plotPointAlpha]], default_color,
             common_size
             # param_choices[[.plotPointSize]]
@@ -1927,16 +1927,16 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
 #'
 #' @importFrom ggplot2 aes
 .build_aes <- function(
-    x = TRUE, y = TRUE, color = FALSE, shape = FALSE, size = FALSE, fill = FALSE,
-    group = FALSE, alt=NULL) {
+    x=TRUE, y=TRUE, color=FALSE, shape=FALSE, size=FALSE, fill=FALSE,
+    group=FALSE, alt=NULL) {
     active_aes <- .all_aes_values[c(x, y, color, shape, size, fill, group)]
     if (!is.null(alt)) {
         active_aes <- c(active_aes, alt)
         active_aes <- active_aes[!duplicated(names(active_aes), fromLast=TRUE)]
     }
     aes_specs <- mapply(
-        FUN = .make_single_aes, names(active_aes), active_aes, USE.NAMES = FALSE)
-    aes_specs <- paste(aes_specs, collapse = ", ")
+        FUN=.make_single_aes, names(active_aes), active_aes, USE.NAMES=FALSE)
+    aes_specs <- paste(aes_specs, collapse=", ")
     return(sprintf("aes(%s)", aes_specs))
 }
 
@@ -1946,14 +1946,14 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
 #' @param value The name of a column in the plot data that will be mapped to
 #' the aesthetic declared in \code{name}.
 #'
-#' @return A character value of the form \code{name = value}.
+#' @return A character value of the form \code{name=value}.
 #'
 #' @author Kevin Rue-Albrecht
 #' @rdname INTERNAL_make_single_aes
 #' @seealso
 #' \code{\link{.build_aes}}.
 .make_single_aes <- function(name, value){
-    sprintf("%s = %s", name, value)
+    sprintf("%s=%s", name, value)
 }
 
 #' Generate ggplot title and label instructions
@@ -1981,15 +1981,15 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
 #' \code{\link{.square_plot}}
 #'
 #' @importFrom ggplot2 labs
-.build_labs <- function(x = NULL, y = NULL, color = NULL, shape = NULL, size = NULL, fill = NULL, group = NULL, title = NULL, subtitle = NULL){
+.build_labs <- function(x=NULL, y=NULL, color=NULL, shape=NULL, size=NULL, fill=NULL, group=NULL, title=NULL, subtitle=NULL){
     labs_specs <- list(x, y, color, shape, size, fill, group, title, subtitle)
     names(labs_specs) <- .all_labs_names
     labs_specs <- labs_specs[lengths(labs_specs)>0L]
     if (identical(length(labs_specs), 0L)){
         return(NULL)
     }
-    labs_specs <- mapply(FUN = .make_single_lab, names(labs_specs), labs_specs, USE.NAMES = FALSE)
-    labs_specs <- paste(labs_specs, collapse = ", ")
+    labs_specs <- mapply(FUN=.make_single_lab, names(labs_specs), labs_specs, USE.NAMES=FALSE)
+    labs_specs <- paste(labs_specs, collapse=", ")
     return(sprintf("labs(%s) +", labs_specs))
 }
 
@@ -1999,14 +1999,14 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
 #' @param value A character value for the title or label declared in
 #' \code{name}.
 #'
-#' @return A character value of the form \code{name = value}.
+#' @return A character value of the form \code{name=value}.
 #'
 #' @author Kevin Rue-Albrecht
 #' @rdname INTERNAL_make_single_lab
 #' @seealso
 #' \code{\link{.build_labs}}.
 .make_single_lab <- function(name, value){
-    sprintf("%s = %s", name, deparse(value))
+    sprintf("%s=%s", name, deparse(value))
 }
 
 ############################################
@@ -2073,13 +2073,13 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
     facet_row <- param_choices[[.facetRowsByColData]]
     if (param_choices[[.facetByRow]]) {
         facet_cmds["FacetRow"] <- sprintf(
-            "plot.data$FacetRow <- colData(se)[,%s];", deparse(facet_row))
+            "plot.data$FacetRow <- colData(se)[, %s];", deparse(facet_row))
     }
 
     facet_column <- param_choices[[.facetColumnsByColData]]
     if (param_choices[[.facetByColumn]]) {
         facet_cmds["FacetColumn"] <- sprintf(
-            "plot.data$FacetColumn <- colData(se)[,%s];", deparse(facet_column))
+            "plot.data$FacetColumn <- colData(se)[, %s];", deparse(facet_column))
     }
 
     return(facet_cmds)
@@ -2092,13 +2092,13 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
     facet_row <- param_choices[[.facetRowsByRowData]]
     if (param_choices[[.facetByRow]]) {
         facet_cmds["FacetRow"] <- sprintf(
-            "plot.data$FacetRow <- rowData(se)[,%s];", deparse(facet_row))
+            "plot.data$FacetRow <- rowData(se)[, %s];", deparse(facet_row))
     }
 
     facet_column <- param_choices[[.facetColumnsByRowData]]
     if (param_choices[[.facetByColumn]]) {
         facet_cmds["FacetColumn"] <- sprintf(
-            "plot.data$FacetColumn <- rowData(se)[,%s];", deparse(facet_column))
+            "plot.data$FacetColumn <- rowData(se)[, %s];", deparse(facet_column))
     }
 
     return(facet_cmds)
@@ -2164,12 +2164,12 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
 #'
 #' @importFrom ggplot2 geom_rect geom_text
 .self_brush_box <- function(param_choices, flip=FALSE) {
-    active <- param_choices[,.brushData][[1]]
-    saved <- param_choices[,.multiSelectHistory][[1]]
+    active <- param_choices[, .brushData][[1]]
+    saved <- param_choices[, .multiSelectHistory][[1]]
 
     keep <- which(!vapply(saved, .is_lasso, FUN.VALUE=TRUE))
     total <- as.integer(!is.null(active)) + length(keep)
-    if (total==0L) {
+    if (total == 0L) {
         return(NULL)
     }
 
@@ -2199,11 +2199,11 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
     fill_color <- brush_fill_color[enc$Type]
 
     # Build up the aesthetics call
-    aes_call <- sprintf("xmin = %s, xmax = %s, ymin = %s, ymax = %s", xmin, xmax, ymin, ymax)
+    aes_call <- sprintf("xmin=%s, xmax=%s, ymin=%s, ymax=%s", xmin, xmax, ymin, ymax)
 
     cmds <- character(0)
     for (i in seq_len(total) - !is.null(active)) {
-        if (i==0L) {
+        if (i == 0L) {
             brush_src <- sprintf("all_brushes[['%s']]", plot_name)
         } else {
             brush_src <- sprintf("all_select_histories[['%s']][[%i]]", plot_name, keep[i])
@@ -2215,15 +2215,15 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
         # Collect additional panel information for the brush
         addPanels <- c()
         if (param_choices[[.facetByRow]]) {
-            addPanels["FacetRow"] <- sprintf("FacetRow = %s[['%s']]", brush_src, facetrow)
+            addPanels["FacetRow"] <- sprintf("FacetRow=%s[['%s']]", brush_src, facetrow)
         }
         if (param_choices[[.facetByColumn]]) {
-            addPanels["FacetColumn"] <- sprintf("FacetColumn = %s[['%s']]", brush_src, facetcolumn)
+            addPanels["FacetColumn"] <- sprintf("FacetColumn=%s[['%s']]", brush_src, facetcolumn)
         }
 
         # If any facting (row, column) is active, add the relevant data fields
         if (length(addPanels)) {
-            panel_list <- sprintf("list(%s)", paste(addPanels, collapse = ", "))
+            panel_list <- sprintf("list(%s)", paste(addPanels, collapse=", "))
             brush_data <- sprintf("append(%s, %s)", brush_data, panel_list)
         }
 
@@ -2289,12 +2289,12 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
 #' @importFrom ggplot2 geom_point geom_polygon geom_path scale_shape_manual
 #' scale_fill_manual guides
 .self_lasso_path <- function(param_choices, flip=FALSE) {
-    active <- param_choices[,.lassoData][[1]]
-    saved <- param_choices[,.multiSelectHistory][[1]]
+    active <- param_choices[, .lassoData][[1]]
+    saved <- param_choices[, .multiSelectHistory][[1]]
 
     keep <- which(vapply(saved, .is_lasso, FUN.VALUE=TRUE))
     total <- as.integer(!is.null(active)) + length(keep)
-    if (total==0L) {
+    if (total == 0L) {
         return(NULL)
     }
 
@@ -2314,7 +2314,7 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
     cmds <- character(0)
     firstClosed <- TRUE
     for (i in seq_len(total) - !is.null(active)) {
-        if (i==0L) {
+        if (i == 0L) {
             lasso_src <- sprintf("all_lassos[['%s']]", plot_name)
             current <- active
         } else {
@@ -2324,15 +2324,15 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
         }
 
         # Initialize the minimal lasso information
-        lasso_data <- sprintf("X = %s$coord[,1], Y = %s$coord[,2]", lasso_src, lasso_src)
+        lasso_data <- sprintf("X=%s$coord[, 1], Y=%s$coord[, 2]", lasso_src, lasso_src)
 
         # Collect additional panel information for the lasso.
         addPanels <- c()
         if (param_choices[[.facetByRow]]) {
-            addPanels["FacetRow"] <- sprintf("FacetRow = %s[['%s']]", lasso_src, facetrow)
+            addPanels["FacetRow"] <- sprintf("FacetRow=%s[['%s']]", lasso_src, facetrow)
         }
         if (param_choices[[.facetByColumn]]) {
-            addPanels["FacetColumn"] <- sprintf("FacetColumn = %s[['%s']]", lasso_src, facetcolumn)
+            addPanels["FacetColumn"] <- sprintf("FacetColumn=%s[['%s']]", lasso_src, facetcolumn)
         }
 
         # If any facting (row, column) is active, add the relevant data fields
@@ -2343,32 +2343,32 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
 
         if (identical(nrow(current$coord), 1L)) { # lasso has only a start point
             point_cmd <- sprintf(
-"geom_point(aes(x = %s, y = %s),
+"geom_point(aes(x=%s, y=%s),
     data=data.frame(%s),
-    inherit.aes=FALSE, alpha=1, stroke = 1, color = '%s', shape = %s)",
+    inherit.aes=FALSE, alpha=1, stroke=1, color='%s', shape=%s)",
                 current$mapping$x, current$mapping$y, lasso_data, stroke_color, .lassoStartShape)
             full_cmd_list <- point_cmd
 
         } else if (current$closed){ # lasso is closed
             polygon_cmd <- sprintf(
-    "geom_polygon(aes(x = %s, y = %s), alpha=%s, color='%s',
+    "geom_polygon(aes(x=%s, y=%s), alpha=%s, color='%s',
         data=data.frame(%s),
-        inherit.aes=FALSE, fill = '%s')",
+        inherit.aes=FALSE, fill='%s')",
                 current$mapping$x, current$mapping$y,
                 .brushFillOpacity, stroke_color,
                 lasso_data, fill_color)
 
             # Put a number for saved lassos.
             if (i!=0L) {
-                text_data <- c(sprintf("X=mean(%s$coord[,1])", lasso_src),
-    				sprintf("Y=mean(%s$coord[,2])", lasso_src),
+                text_data <- c(sprintf("X=mean(%s$coord[, 1])", lasso_src),
+    				sprintf("Y=mean(%s$coord[, 2])", lasso_src),
     				addPanels)
 
                 text_cmd <- sprintf(
-"geom_text(aes(x = %s, y=%s), inherit.aes=FALSE,
+"geom_text(aes(x=%s, y=%s), inherit.aes=FALSE,
     data=data.frame(
         %s),
-    label = %i, size = %s, colour = '%s')",
+    label=%i, size=%s, colour='%s')",
 	                current$mapping$x, current$mapping$y,
     				paste(text_data, collapse=",\n        "),
                     chosen, param_choices[[.plotFontSize]] * .plotFontSizeLegendTextDefault, stroke_color)
@@ -2381,11 +2381,11 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
             if (firstClosed) {
                 # Commands to put only once
                 scale_fill_cmd <- sprintf(
-                    "scale_fill_manual(values = c('TRUE' = '%s', 'FALSE' = '%s'), labels = NULL)",
+                    "scale_fill_manual(values=c('TRUE'='%s', 'FALSE'='%s'), labels=NULL)",
                     stroke_color, fill_color)
 
                 if (param_choices[[.shapeByField]] == .shapeByNothingTitle) {
-                    guides_cmd <- "guides(shape = 'none')"
+                    guides_cmd <- "guides(shape='none')"
                 }
                 firstClosed <- FALSE
             }
@@ -2394,42 +2394,42 @@ plot.data[%s, 'ColorBy'] <- TRUE;", deparse(chosen_gene))))
 
         } else { # lasso is still open
             path_cmd <- sprintf(
-"geom_path(aes(x = %s, y = %s),
+"geom_path(aes(x=%s, y=%s),
     data=data.frame(%s),
-    inherit.aes=FALSE, alpha=1, color='%s', linetype = 'longdash')",
+    inherit.aes=FALSE, alpha=1, color='%s', linetype='longdash')",
                 current$mapping$x, current$mapping$y, lasso_data, stroke_color)
 
             # Do not control the shape of waypoints if shape is already being mapped to a covariate
             if (param_choices[[.shapeByField]] == .shapeByNothingTitle) {
                 point_cmd <- sprintf(
-"geom_point(aes(x = %s, y = %s, shape = First),
+"geom_point(aes(x=%s, y=%s, shape=First),
     data=data.frame(%s,
-        First = seq_len(nrow(%s$coord))==1L),
-    inherit.aes=FALSE, alpha=1, stroke = 1, color = '%s')",
+        First=seq_len(nrow(%s$coord)) == 1L),
+    inherit.aes=FALSE, alpha=1, stroke=1, color='%s')",
                     current$mapping$x, current$mapping$y,
                     lasso_data, lasso_src, stroke_color)
 
                 scale_shape_cmd <- sprintf(
-                    "scale_shape_manual(values = c('TRUE' = %s, 'FALSE' = %s))",
+                    "scale_shape_manual(values=c('TRUE'=%s, 'FALSE'=%s))",
                     .lassoStartShape, .lassoWaypointShape
                 )
 
-                guides_cmd <- "guides(shape = 'none')"
+                guides_cmd <- "guides(shape='none')"
             } else {
                 point_cmd <- sprintf(
-"geom_point(aes(x = %s, y = %s, size = First),
+"geom_point(aes(x=%s, y=%s, size=First),
     data=data.frame(%s,
-        First = seq_len(nrow(%s$coord))==1L),
-    inherit.aes=FALSE, alpha=1, stroke = 1, shape = %s, color = '%s')",
+        First=seq_len(nrow(%s$coord)) == 1L),
+    inherit.aes=FALSE, alpha=1, stroke=1, shape=%s, color='%s')",
                     current$mapping$x, current$mapping$y,
                     lasso_data, lasso_src, .lassoStartShape, stroke_color)
 
                 scale_shape_cmd <- sprintf(
-                    "scale_size_manual(values = c('TRUE' = %s, 'FALSE' = %s))",
+                    "scale_size_manual(values=c('TRUE'=%s, 'FALSE'=%s))",
                     .lassoStartSize, .lassoWaypointSize
                 )
 
-                guides_cmd <- "guides(size = 'none')"
+                guides_cmd <- "guides(size='none')"
             }
 
             full_cmd_list <- c(path_cmd, point_cmd, scale_shape_cmd, guides_cmd)

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,6 +1,12 @@
 \name{NEWS}
 \title{News for Package 'iSEE'}
 
+\section{iSEE VERSION 1.5.8}{
+\itemize{
+    \item Substitute deprecated \code{scater::normalize} by \code{logNormCounts}.
+}
+}
+
 \section{iSEE VERSION 1.5.7}{
 \itemize{
     \item Simplify protection of \code{redDimPlotDefaults} against empty \code{reducedDims}.

--- a/man/annotateEnsembl.Rd
+++ b/man/annotateEnsembl.Rd
@@ -35,7 +35,7 @@ based on the data retrieved from the ENSEMBL database
 }
 \examples{
 library(scRNAseq)
-sce <- ReprocessedAllenData(assays = "tophat_counts")
+sce <- ReprocessedAllenData(assays="tophat_counts")
 library(org.Mm.eg.db)
 myfun <- annotateEnsembl(sce, org.Mm.eg.db, keytype="SYMBOL")
 \dontrun{

--- a/man/annotateEntrez.Rd
+++ b/man/annotateEntrez.Rd
@@ -30,7 +30,7 @@ based on the data retrieved from the ENTREZ database
 }
 \examples{
 library(scRNAseq)
-sce <- ReprocessedAllenData(assays = "tophat_counts")
+sce <- ReprocessedAllenData(assays="tophat_counts")
 
 library(org.Mm.eg.db)
 myfun <- annotateEntrez(sce, org.Mm.eg.db, keytype="SYMBOL")

--- a/man/iSEE.Rd
+++ b/man/iSEE.Rd
@@ -121,17 +121,16 @@ To raise the limit (e.g., 50MB), run \code{options(shiny.maxRequestSize=50*1024^
 library(scRNAseq)
 
 # Example data ----
-sce <- ReprocessedAllenData(assays = "tophat_counts")
+sce <- ReprocessedAllenData(assays="tophat_counts")
 class(sce)
 
 library(scater)
-counts(sce) <- assay(sce, "tophat_counts")
-sce <- normalize(sce)
+sce <- logNormCounts(sce, exprs_values="tophat_counts")
 
 sce <- runPCA(sce, ncomponents=4)
 sce <- runTSNE(sce)
-rowData(sce)$ave_count <- rowMeans(counts(sce))
-rowData(sce)$n_cells <- rowSums(counts(sce)>0)
+rowData(sce)$ave_count <- rowMeans(assay(sce, "tophat_counts"))
+rowData(sce)$n_cells <- rowSums(assay(sce, "tophat_counts") > 0)
 sce
 
 # launch the app itself ----

--- a/man/isColorMapCompatible.Rd
+++ b/man/isColorMapCompatible.Rd
@@ -53,8 +53,7 @@ ecm <- ExperimentColorMap(
 # Example SingleCellExperiment ----
 
 library(scRNAseq)
-sce <- ReprocessedAllenData(assays = "tophat_counts")
-library(scater)
+sce <- ReprocessedAllenData(assays="tophat_counts")
 
 # Test for compatibility ----
 

--- a/man/modeGating.Rd
+++ b/man/modeGating.Rd
@@ -32,19 +32,18 @@ object.
 }
 \examples{
 library(scRNAseq)
+
 # Example data ----
-sce <- ReprocessedAllenData(assays = "tophat_counts")
+sce <- ReprocessedAllenData(assays="tophat_counts")
 class(sce)
 
 library(scater)
-counts(sce) <- assay(sce, "tophat_counts")
-sce <- normalize(sce)
-
+sce <- logNormCounts(sce, exprs_values="tophat_counts")
 
 # Select top variable genes ----
 
 plot_count <- 6
-rv <- rowVars(logcounts(sce))
+rv <- rowVars(assay(sce, "tophat_counts"))
 top_var <- head(order(rv, decreasing=TRUE), plot_count*2)
 top_var_genes <- rownames(sce)[top_var]
 

--- a/man/synchronizeAssays.Rd
+++ b/man/synchronizeAssays.Rd
@@ -85,10 +85,9 @@ ecm <- ExperimentColorMap(
 # Example SingleCellExperiment ----
 
 library(scRNAseq)
-sce <- ReprocessedAllenData(assays = "tophat_counts")
+sce <- ReprocessedAllenData(assays="tophat_counts")
 library(scater)
-counts(sce) <- assay(sce, "tophat_counts")
-sce <- normalize(sce)
+sce <- logNormCounts(sce, exprs_values="tophat_counts")
 sce <- runPCA(sce)
 sce <- runTSNE(sce)
 

--- a/tests/testthat/setup_sce.R
+++ b/tests/testthat/setup_sce.R
@@ -6,13 +6,12 @@ stopifnot(
 # Example data ----
 sce <- ReprocessedAllenData(assays = "tophat_counts")
 
-counts(sce) <- assay(sce, "tophat_counts")
-sce <- normalize(sce)
+sce <- logNormCounts(sce, exprs_values="tophat_counts")
 sce <- runPCA(sce)
 sce <- runTSNE(sce)
 
-rowData(sce)$num_cells <- rowSums(counts(sce)>0)
-rowData(sce)$mean_count <- rowMeans(counts(sce))
+rowData(sce)$num_cells <- rowSums(assay(sce, "tophat_counts") > 0)
+rowData(sce)$mean_count <- rowMeans(assay(sce, "tophat_counts"))
 # Add a groupable field in rowData
 rowData(sce)$letters <- sample(letters[1:3], nrow(sce), TRUE)
 

--- a/tests/testthat/test_ExperimentColorMap.R
+++ b/tests/testthat/test_ExperimentColorMap.R
@@ -724,7 +724,7 @@ test_that("isColorMapCompatible accepts compatible colormap", {
 
     ecm <- ExperimentColorMap(
         assays = list(
-            counts = COUNT_COLORS
+            tophat_counts = COUNT_COLORS
         ),
         global_continuous = ASSAY_CONTINUOUS_COLORS
     )
@@ -756,7 +756,6 @@ test_that("synchronizeAssays works for fully named assays", {
     ecm_expected <- ExperimentColorMap(
         assays = list(
             tophat_counts = COUNT_COLORS,
-            counts = COUNT_COLORS,
             logcounts = iSEE:::.defaultContinuousColorMap
         )
     )
@@ -790,7 +789,8 @@ test_that("synchronizeAssays requires same number of unnamed assays", {
     ecm_unmatched <- ExperimentColorMap(
         assays = list(
             COUNT_COLORS,
-            test = COUNT_COLORS
+            test = COUNT_COLORS,
+            test2 = COUNT_COLORS
         )
     )
 
@@ -812,8 +812,7 @@ test_that("synchronizeAssays works for fully _un_named assays", {
     ecm_matched <- ExperimentColorMap(
         assays = list(
             COUNT_COLORS,
-            FPKM_COLORS,
-            COUNT_COLORS
+            FPKM_COLORS
         )
     )
 
@@ -836,17 +835,17 @@ test_that("synchronizeAssays works for fully _un_named assays", {
 
 test_that("synchronizeAssays works for partially named assays", {
 
-    sce_some_names <- sce
-    assayNames(sce_some_names)[1] <- ""
+    sce_some_names <- sce # tophat_counts, logcounts [1, 2]
+    counts(sce_some_names) <- assay(sce_some_names, "tophat_counts") # counts [3]
+    assayNames(sce_some_names)[3] <- ""
 
     ecm <- ExperimentColorMap(
         assays = list(
-            counts = COUNT_COLORS,
             tophat_counts = COUNT_COLORS,
-            cufflinks_fpkm = FPKM_COLORS,
+            cufflinks_fpkm = FPKM_COLORS, # missing colormap
             rsem_tpm = FPKM_COLORS, # missing colormap
-            orphan = COUNT_COLORS,
-            orphan2 = COUNT_COLORS,
+            orphan = COUNT_COLORS, # missing colormap
+            orphan2 = COUNT_COLORS, # missing colormap
             COUNT_COLORS,
             TPM_COLORS
         )
@@ -856,16 +855,16 @@ test_that("synchronizeAssays works for partially named assays", {
 
     ecm_expected <- ExperimentColorMap(
         assays = list(
-            iSEE:::.defaultContinuousColorMap,
-            counts = COUNT_COLORS,
-            logcounts = iSEE:::.defaultContinuousColorMap
+            tophat_counts = COUNT_COLORS,
+            logcounts = iSEE:::.defaultContinuousColorMap,
+            iSEE:::.defaultContinuousColorMap
         )
     )
 
     # Expect:
-    # - unnamed assays to be assigned default continuous colormap
-    # - named assays matched to have the appropriate colormap
-    # - named assays unmatched to have the default continuous colormap
+    # - named assays matched to have the appropriate colormap (tophat_counts)
+    # - named assays unmatched to have the default continuous colormap (logcounts)
+    # - unnamed assays to be assigned default continuous colormap (3rd assay)
     expect_identical(
         ecm_sync,
         ecm_expected
@@ -878,4 +877,3 @@ test_that("synchronizeAssays works for partially named assays", {
     )
 
 })
-

--- a/tests/testthat/test_defaults.R
+++ b/tests/testthat/test_defaults.R
@@ -13,7 +13,8 @@ test_that("redDimPlotDefaults supports objects without reduced dimensions", {
 
 test_that(".set_default_assay returns 1L there is no logcounts assay", {
     sce_noLogCount <- sce
-    assays(sce_noLogCount) <- assays(sce_noLogCount)["counts"]
+    keep <- which(assayNames(sce_noLogCount) != "logcounts")
+    assays(sce_noLogCount) <- assays(sce_noLogCount)[keep]
 
     expect_identical(iSEE:::.set_default_assay(sce_noLogCount), 1L)
 })

--- a/tests/testthat/test_heatmap.R
+++ b/tests/testthat/test_heatmap.R
@@ -8,12 +8,12 @@ heatMapArgs <- heatMapPlotDefaults(sce, 1)
 redDimArgs$Type <- 2L
 redDimArgs[[iSEE:::.colorByField]] <- iSEE:::.colorByColDataTitle
 redDimArgs[[iSEE:::.colorByColData]] <- "driver_1_s"
-redDimArgs$BrushData <- list(list(xmin = -5.8936302389057, xmax = 2.3755515915654, ymin = 4.3811474670046, ymax = 12.602031654675,
-    mapping = list(x = "X", y = "Y"), domain = list(left = -9.30648713007475, right = 11.286214260173,
-        bottom = -9.17816645795467, top = 13.1270784675571), range = list(left = 35.3889661815069,
-        right = 386.520547945205, bottom = 466.050486943493, top = 23.7921069615253),
-    log = list(x = NULL, y = NULL), direction = "xy", brushId = "redDimPlot1_Brush",
-    outputId = "redDimPlot1"))
+redDimArgs$BrushData <- list(list(xmin=-5.8936302389057, xmax=2.3755515915654, ymin=4.3811474670046, ymax=12.602031654675,
+    mapping=list(x="X", y="Y"), domain=list(left=-9.30648713007475, right=11.286214260173,
+        bottom=-9.17816645795467, top=13.1270784675571), range=list(left=35.3889661815069,
+        right=386.520547945205, bottom=466.050486943493, top=23.7921069615253),
+    log=list(x=NULL, y=NULL), direction="xy", brushId="redDimPlot1_Brush",
+    outputId="redDimPlot1"))
 
 heatMapArgs[[iSEE:::.heatMapFeatName]][[1]] <- head(which(rowData(sce)[, "num_cells"] == ncol(sce)), 100)
 heatMapArgs[[iSEE:::.heatMapColData]][[1]] <- c("driver_1_s", "NREADS")
@@ -53,7 +53,7 @@ all_coordinates[["redDimPlot1"]] <- p.out$xy[, intersect(iSEE:::.allCoordinatesN
 
 test_that(".make_heatMapPlot with groupable and non-groupable colData", {
 
-    out <- iSEE:::.make_heatMapPlot(1, all_memory, all_coordinates, se = sce, colormap = ExperimentColorMap())
+    out <- iSEE:::.make_heatMapPlot(1, all_memory, all_coordinates, se=sce, colormap=ExperimentColorMap())
 
     expect_named(out, c("cmd_list", "xy", "plot", "legends"))
     expect_true(any(grepl("driver_1_s", out$cmd_list$data)))
@@ -76,20 +76,20 @@ test_that(".make_heatMapPlot works with incoming selection", {
     all_memory$heatMapPlot$SelectByPlot <- "Reduced dimension plot 1"
     all_memory$heatMapPlot$SelectEffect <- iSEE:::.selectTransTitle
 
-    out <- iSEE:::.make_heatMapPlot(1, all_memory, all_coordinates, se = sce, colormap = ExperimentColorMap())
+    out <- iSEE:::.make_heatMapPlot(1, all_memory, all_coordinates, se=sce, colormap=ExperimentColorMap())
 
     expect_named(out, c("cmd_list", "xy", "plot", "legends"))
     expect_true(any(grepl("driver_1_s", out$cmd_list$data)))
     expect_true(any(grepl("NREADS", out$cmd_list$data)))
-    expect_true(any(grepl("geom_raster(aes(fill = OrderBy1, alpha=SelectBy)) +", out$cmd_list$annot, fixed = TRUE)))
+    expect_true(any(grepl("geom_raster(aes(fill=OrderBy1, alpha=SelectBy)) +", out$cmd_list$annot, fixed=TRUE)))
 
     ## Color effect for selection
 
     all_memory$heatMapPlot$SelectEffect <- iSEE:::.selectColorTitle
 
-    out <- iSEE:::.make_heatMapPlot(1, all_memory, all_coordinates, se = sce, colormap = ExperimentColorMap())
+    out <- iSEE:::.make_heatMapPlot(1, all_memory, all_coordinates, se=sce, colormap=ExperimentColorMap())
 
-    expect_true(any(grepl("geom_raster(aes(fill = SelectBy))", out$cmd_list$annot, fixed = TRUE)))
+    expect_true(any(grepl("geom_raster(aes(fill=SelectBy))", out$cmd_list$annot, fixed=TRUE)))
 
 })
 
@@ -103,7 +103,7 @@ test_that(".get_colorscale_limits produces expected color scale limits", {
     lower.bound <- -Inf
     upper.bound <- Inf
 
-    out <- iSEE:::.get_colorscale_limits(min.value, max.value, lower.bound, upper.bound, include.zero = TRUE)
+    out <- iSEE:::.get_colorscale_limits(min.value, max.value, lower.bound, upper.bound, include.zero=TRUE)
     expect_identical(out, c(min.value, 0, max.value))
 
     out <- iSEE:::.get_colorscale_limits(min.value, max.value, lower.bound, upper.bound, include.zero=FALSE)
@@ -113,7 +113,7 @@ test_that(".get_colorscale_limits produces expected color scale limits", {
     lower.bound <- -0.5
     upper.bound <- 0.5
 
-    out <- iSEE:::.get_colorscale_limits(min.value, max.value, lower.bound, upper.bound, include.zero = TRUE)
+    out <- iSEE:::.get_colorscale_limits(min.value, max.value, lower.bound, upper.bound, include.zero=TRUE)
     expect_identical(out, c(lower.bound, 0, upper.bound))
 
     out <- iSEE:::.get_colorscale_limits(min.value, max.value, lower.bound, upper.bound, include.zero=FALSE)
@@ -215,11 +215,11 @@ test_that(".get_heatmap_fill_cmd works when not centred", {
     out <- iSEE:::.get_heatmap_fill_cmd(param_choices, ExperimentColorMap(), min.obs, max.obs)
     expect_match(
         out,
-        "colors=c('#440154FF',assayColorMap(colormap, '3', discrete=FALSE)(21L),'#FDE725FF')",
+        "colors=c('#440154FF', assayColorMap(colormap, '2', discrete=FALSE)(21L), '#FDE725FF')",
         fixed=TRUE)
     expect_match(
         out,
-        "values=scales::rescale(c(-6,seq(-0.5,0.5,length.out=21L),6), to=c(0,1), from=c(-6,6))",
+        "values=scales::rescale(c(-6, seq(-0.5, 0.5, length.out=21L), 6), to=c(0, 1), from=c(-6, 6))",
         fixed=TRUE)
 
     # Disabling the upper limit only adds an additional lower color and break (to the left)
@@ -231,11 +231,11 @@ test_that(".get_heatmap_fill_cmd works when not centred", {
     out <- iSEE:::.get_heatmap_fill_cmd(param_choices, ExperimentColorMap(), min.obs, max.obs)
     expect_match(
         out,
-        "colors=c('#440154FF',assayColorMap(colormap, '3', discrete=FALSE)(21L))",
+        "colors=c('#440154FF', assayColorMap(colormap, '2', discrete=FALSE)(21L))",
         fixed=TRUE)
     expect_match(
         out,
-        "values=scales::rescale(c(-6,seq(-0.5,6,length.out=21L)), to=c(0,1), from=c(-6,6))",
+        "values=scales::rescale(c(-6, seq(-0.5, 6, length.out=21L)), to=c(0, 1), from=c(-6, 6))",
         fixed=TRUE)
 
     # Disabling the lower limit only adds an additional upper color and break (to the right)
@@ -247,11 +247,11 @@ test_that(".get_heatmap_fill_cmd works when not centred", {
     out <- iSEE:::.get_heatmap_fill_cmd(param_choices, ExperimentColorMap(), min.obs, max.obs)
     expect_match(
         out,
-        "colors=c(assayColorMap(colormap, '3', discrete=FALSE)(21L),'#FDE725FF')",
+        "colors=c(assayColorMap(colormap, '2', discrete=FALSE)(21L), '#FDE725FF')",
         fixed=TRUE)
     expect_match(
         out,
-        "values=scales::rescale(c(seq(-6,0.5,length.out=21L),6), to=c(0,1), from=c(-6,6))",
+        "values=scales::rescale(c(seq(-6, 0.5, length.out=21L), 6), to=c(0, 1), from=c(-6, 6))",
         fixed=TRUE)
 
 })

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -186,7 +186,7 @@ test_that("memory setup works correctly", {
     expect_identical(memory$customStatTable$Arguments, character(nrow(memory$customStatTable)))
     expect_identical(memory$customStatTable$VisibleArgs, c("WHEE", "", ""))
 
-    expect_identical(memory$heatMapPlot$Assay, c(1L, 3L))
+    expect_identical(memory$heatMapPlot$Assay, c(1L, 2L))
 
     # Works correctly when the number of arguments is greater than max.
     memory <- iSEE:::.setup_memory(

--- a/tests/testthat/test_plotting.R
+++ b/tests/testthat/test_plotting.R
@@ -419,8 +419,8 @@ test_that(".make_rowDataPlot/.violin_plot produce a valid xy with color", {
 
 test_that(".make_rowDataPlot/.square_plot produce a valid list",{
 
-    rowData(sce)[,"letters"] <- sample(letters[1:5], nrow(sce), replace=TRUE)
-    rowData(sce)[,"LETTERS"] <- sample(LETTERS[1:3], nrow(sce), replace=TRUE)
+    rowData(sce)[, "letters"] <- sample(letters[1:5], nrow(sce), replace=TRUE)
+    rowData(sce)[, "LETTERS"] <- sample(LETTERS[1:3], nrow(sce), replace=TRUE)
 
     all_memory$rowDataPlot[1, iSEE:::.rowDataXAxis] <- iSEE:::.rowDataXAxisRowData
     all_memory$rowDataPlot[1, iSEE:::.rowDataXAxisRowData] <- "letters"
@@ -469,8 +469,8 @@ test_that(".make_rowDataPlot/.square_plot produce a valid list",{
 
 test_that(".make_rowDataPlot/.square_plot produce a valid xy with color",{
 
-    rowData(sce)[,"letters"] <- sample(letters[1:5], nrow(sce), replace=TRUE)
-    rowData(sce)[,"LETTERS"] <- sample(LETTERS[1:3], nrow(sce), replace=TRUE)
+    rowData(sce)[, "letters"] <- sample(letters[1:5], nrow(sce), replace=TRUE)
+    rowData(sce)[, "LETTERS"] <- sample(LETTERS[1:3], nrow(sce), replace=TRUE)
 
     all_memory$rowDataPlot[1, iSEE:::.rowDataXAxis] <- iSEE:::.rowDataXAxisRowData
     all_memory$rowDataPlot[1, iSEE:::.rowDataXAxisRowData] <- "letters"
@@ -750,7 +750,7 @@ test_that(".make_sampAssayPlot works with X variable set to Sample name", {
 
     expect_match(
         p.out$cmd_list$data[["x"]],
-        sprintf("plot.data$X <- assay(se, 3, withDimnames=FALSE)[,%i];", selected_sample),
+        sprintf("plot.data$X <- assay(se, 2, withDimnames=FALSE)[, %i];", selected_sample),
         fixed=TRUE)
 
     expect_match(p.out$cmd_list$plot[["labs"]], colnames(sce)[selected_sample], fixed=TRUE)
@@ -798,10 +798,10 @@ test_that(".scatter_plot works with zoom",{
     # Identify range of data
     params <- all_memory$redDimPlot[1, ]
     x_range <- range(head(
-        reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimXAxis]]]
+        reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimXAxis]]]
     ), 10)
     y_range <- range(head(
-        reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimYAxis]]]
+        reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimYAxis]]]
     ), 10)
     # Set zoom min/max to the first two distinct values in X/Y direction
     zoom_range <- c(x_range, y_range)
@@ -814,8 +814,8 @@ test_that(".scatter_plot works with zoom",{
 
     params <- all_memory$redDimPlot[1, ]
     expected_xy <- data.frame(
-        X=reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimXAxis]]],
-        Y=reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimYAxis]]],
+        X=reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimXAxis]]],
+        Y=reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimYAxis]]],
         row.names=colnames(sce)
     )
 
@@ -852,12 +852,12 @@ test_that(".make_colDataPlot/.violin_plot works with zoom",{
 
     params <- all_memory$colDataPlot[1, ]
     expected_xy <- data.frame(
-        Y=colData(sce)[,params[[iSEE:::.colDataYAxis]]],
-        X=colData(sce)[,params[[iSEE:::.colDataXAxisColData]]],
+        Y=colData(sce)[, params[[iSEE:::.colDataYAxis]]],
+        X=colData(sce)[, params[[iSEE:::.colDataXAxisColData]]],
         row.names=colnames(sce)
     )
 
-    expect_identical(p.out$xy[,c("Y", "X")], expected_xy)
+    expect_identical(p.out$xy[, c("Y", "X")], expected_xy)
 
 })
 
@@ -893,8 +893,8 @@ test_that(".make_colDataPlot/.violin_plot works with zoom",{
     # This requires some finesse to deal with horizontal plots
     # where the X and Y coordinates are flipped to draw the violins
     expected_xy <- data.frame(
-        Y=colData(sce)[,params[[iSEE:::.colDataXAxisColData]]], # Y/X switch
-        X=colData(sce)[,params[[iSEE:::.colDataYAxis]]], # X/Y switch
+        Y=colData(sce)[, params[[iSEE:::.colDataXAxisColData]]], # Y/X switch
+        X=colData(sce)[, params[[iSEE:::.colDataYAxis]]], # X/Y switch
         row.names=colnames(sce)
     )
 
@@ -933,8 +933,8 @@ test_that(".make_colDataPlot/.square_plot works with zoom",{
 
     params <- all_memory$colDataPlot[1, ]
     expected_xy <- data.frame(
-        Y=colData(sce)[,params[[iSEE:::.colDataYAxis]]],
-        X=colData(sce)[,params[[iSEE:::.colDataXAxisColData]]],
+        Y=colData(sce)[, params[[iSEE:::.colDataYAxis]]],
+        X=colData(sce)[, params[[iSEE:::.colDataXAxisColData]]],
         row.names=colnames(sce)
     )
 
@@ -950,7 +950,7 @@ test_that(".define_colorby_for_column_plot handles feature selection", {
     params[[iSEE:::.colorByFeatName]] <- 1L
 
     color_out <- iSEE:::.define_colorby_for_column_plot(params, sce)
-    expect_match(color_out$cmds, "assay(se, 3, withDimnames=FALSE)[1,]", fixed=TRUE)
+    expect_match(color_out$cmds, "assay(se, 2, withDimnames=FALSE)[1, ]", fixed=TRUE)
 
     expect_match(
         color_out$label,
@@ -1001,7 +1001,7 @@ test_that("define_shapeby_for_column_plot produces the expected commands", {
     color_out <- iSEE:::.define_shapeby_for_column_plot(params, sce)
     expect_identical(color_out, list(
         label="driver_1_s",
-        cmds="plot.data$ShapeBy <- colData(se)[,\"driver_1_s\"];"))
+        cmds="plot.data$ShapeBy <- colData(se)[, \"driver_1_s\"];"))
 
 })
 
@@ -1015,7 +1015,7 @@ test_that(".define_shapeby_for_row_plot produces the expected commands", {
     color_out <- iSEE:::.define_shapeby_for_row_plot(params, sce)
     expect_identical(color_out, list(
         label="letters",
-        cmds="plot.data$ShapeBy <- rowData(se)[,\"letters\"];"))
+        cmds="plot.data$ShapeBy <- rowData(se)[, \"letters\"];"))
 
 })
 
@@ -1029,14 +1029,14 @@ test_that("define_sizeby_for_column_plot produces the expected commands", {
     color_out <- iSEE:::.define_sizeby_for_column_plot(params, sce)
     expect_identical(color_out, list(
         label="NREADS",
-        cmds="plot.data$SizeBy <- colData(se)[,\"NREADS\"];"))
+        cmds="plot.data$SizeBy <- colData(se)[, \"NREADS\"];"))
 
     all_memory_sb <- all_memory
     all_memory_sb$redDimPlot[1, ] <- params
     p.out <- iSEE:::.make_redDimPlot(
         id=1, all_memory_sb, all_coordinates, sce, ExperimentColorMap())
     expect_equivalent(p.out$cmd_list$plot["points.point"],
-                      "geom_point(aes(x = X, y = Y, size = SizeBy), alpha = 1, plot.data, color='black') +")
+                      "geom_point(aes(x=X, y=Y, size=SizeBy), alpha=1, plot.data, color='black') +")
 })
 
 # .define_sizeby_for_row_plot ----
@@ -1049,7 +1049,7 @@ test_that(".define_sizeby_for_row_plot produces the expected commands", {
     color_out <- iSEE:::.define_sizeby_for_row_plot(params, sce)
     expect_identical(color_out, list(
         label="mean_count",
-        cmds="plot.data$SizeBy <- rowData(se)[,\"mean_count\"];"))
+        cmds="plot.data$SizeBy <- rowData(se)[, \"mean_count\"];"))
 
 })
 
@@ -1063,7 +1063,7 @@ test_that(".define_colorby_for_row_plot handles sample selection", {
     color_out <- iSEE:::.define_colorby_for_row_plot(params, sce)
     expect_identical(color_out, list(
         label="SRR2140055\n(tophat_counts)",
-        cmds="plot.data$ColorBy <- assay(se, 1, withDimnames=FALSE)[,3];"))
+        cmds="plot.data$ColorBy <- assay(se, 1, withDimnames=FALSE)[, 3];"))
 
     color_add <- iSEE:::.add_color_to_row_plot(assay(sce)[1, ], params)
 
@@ -1152,10 +1152,10 @@ test_that(".process_selectby_choice works when sender is another plot", {
     # Set up the selected data (in redDim1)
     params <- all_memory$redDimPlot[1, ]
     x_10 <- head(
-        reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimXAxis]]],
+        reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimXAxis]]],
         10)
     y_10 <- head(
-        reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimYAxis]]],
+        reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimYAxis]]],
         10)
     all_memory$redDimPlot[[iSEE:::.brushData]][1] <- list(list(
         xmin=min(x_10), xmax=max(x_10), ymin=min(y_10), ymax=max(y_10),
@@ -1218,10 +1218,10 @@ test_that(".process_selectby_choice works when sender is self plot", {
     # Set up the selected data (in redDim1)
     params <- all_memory$redDimPlot[1, ]
     x_10 <- head(
-        reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimXAxis]]],
+        reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimXAxis]]],
         10)
     y_10 <- head(
-        reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimYAxis]]],
+        reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimYAxis]]],
         10)
     all_memory$redDimPlot[[iSEE:::.brushData]][1] <- list(list(
         xmin=min(x_10), xmax=max(x_10), ymin=min(y_10), ymax=max(y_10),
@@ -1256,10 +1256,10 @@ test_that(".process_selectby_choice works with closed lasso selection", {
     # Set up the selected data (in redDim1)
     params <- all_memory$redDimPlot[1, ]
     x_10 <- head(
-        reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimXAxis]]],
+        reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimXAxis]]],
         10)
     y_10 <- head(
-        reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimYAxis]]],
+        reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimYAxis]]],
         10)
 
     new_lasso <- list(lasso=NULL, closed=TRUE, panelvar1=NULL,
@@ -1308,10 +1308,10 @@ test_that(".create_points handles transparency selection effect", {
     # Set up the selected data (in redDim1)
     params <- all_memory$redDimPlot[1, ]
     x_10 <- head(
-        reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimXAxis]]],
+        reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimXAxis]]],
         10)
     y_10 <- head(
-        reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimYAxis]]],
+        reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimYAxis]]],
         10)
     all_memory$redDimPlot[[iSEE:::.brushData]][1] <- list(list(
         xmin=min(x_10), xmax=max(x_10), ymin=min(y_10), ymax=max(y_10),
@@ -1345,10 +1345,10 @@ test_that(".create_points handles coloured selection effect", {
     # Set up the selected data (in redDim1)
     params <- all_memory$redDimPlot[1, ]
     x_10 <- head(
-        reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimXAxis]]],
+        reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimXAxis]]],
         10)
     y_10 <- head(
-        reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimYAxis]]],
+        reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimYAxis]]],
         10)
     all_memory$redDimPlot[[iSEE:::.brushData]][1] <- list(list(
         xmin=min(x_10), xmax=max(x_10), ymin=min(y_10), ymax=max(y_10),
@@ -1387,10 +1387,10 @@ test_that(".create_points handles restrict selection effect", {
     # Set up the selected data (in redDim1)
     params <- all_memory$redDimPlot[1, ]
     x_10 <- head(
-        reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimXAxis]]],
+        reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimXAxis]]],
         10)
     y_10 <- head(
-        reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimYAxis]]],
+        reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimYAxis]]],
         10)
     all_memory$redDimPlot[[iSEE:::.brushData]][1] <- list(list(
         xmin=min(x_10), xmax=max(x_10), ymin=min(y_10), ymax=max(y_10),
@@ -1423,10 +1423,10 @@ test_that(".self_lasso_path work with a single point", {
     # Set up the selected data (in redDim1)
     params <- all_memory$redDimPlot[1, ]
     x_10 <- head(
-        reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimXAxis]]],
+        reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimXAxis]]],
         10)
     y_10 <- head(
-        reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimYAxis]]],
+        reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimYAxis]]],
         10)
 
     new_lasso <- list(lasso=NULL, closed=FALSE, panelvar1=NULL,
@@ -1456,10 +1456,10 @@ test_that(".self_lasso_path work with an open path", {
     # Set up the selected data (in redDim1)
     params <- all_memory$redDimPlot[1, ]
     x_10 <- head(
-        reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimXAxis]]],
+        reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimXAxis]]],
         10)
     y_10 <- head(
-        reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimYAxis]]],
+        reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimYAxis]]],
         10)
 
     new_lasso <- list(lasso=NULL, closed=FALSE, panelvar1=NULL,
@@ -1490,11 +1490,11 @@ test_that(".self_lasso_path work with an open path", {
     )
     expect_identical(
         lasso_cmd[3],
-        "scale_shape_manual(values = c('TRUE' = 22, 'FALSE' = 20))"
+        "scale_shape_manual(values=c('TRUE'=22, 'FALSE'=20))"
     )
     expect_identical(
         lasso_cmd[4],
-        "guides(shape = 'none')"
+        "guides(shape='none')"
     )
 
 })
@@ -1504,10 +1504,10 @@ test_that(".self_lasso_path work with a closed and flipped path", {
     # Set up the selected data (in redDim1)
     params <- all_memory$redDimPlot[1, ]
     x_10 <- head(
-        reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimXAxis]]],
+        reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimXAxis]]],
         10)
     y_10 <- head(
-        reducedDim(sce, params[[iSEE:::.redDimType]])[,params[[iSEE:::.redDimYAxis]]],
+        reducedDim(sce, params[[iSEE:::.redDimType]])[, params[[iSEE:::.redDimYAxis]]],
         10)
 
     new_lasso <- list(lasso=NULL, closed=TRUE, panelvar1=NULL,
@@ -1530,7 +1530,7 @@ test_that(".self_lasso_path work with a closed and flipped path", {
 
     expect_match(lasso_cmd[1], "geom_polygon", fixed=TRUE)
     expect_match(lasso_cmd[2], "scale_fill_manual", fixed=TRUE)
-    expect_identical(lasso_cmd[3], "guides(shape = 'none')")
+    expect_identical(lasso_cmd[3], "guides(shape='none')")
 
 })
 
@@ -1686,7 +1686,7 @@ test_that(".downsample_points produces the appropriate code", {
     )
     assign("plot.data", plotData, envir=envir)
     assign("plot.type", "violin_horizontal", envir=envir)
-    # assign("plot.type", "violin", envir = envir)
+    # assign("plot.type", "violin", envir=envir)
 
     out <- iSEE:::.downsample_points(all_memory$colDataPlot[1, ], envir)
     expect_identical(out, c(
@@ -1714,7 +1714,7 @@ test_that(".downsample_points produces the appropriate code", {
     )
     assign("plot.data", plotData, envir=envir)
     assign("plot.type", "violin_horizontal", envir=envir)
-    # assign("plot.type", "violin", envir = envir)
+    # assign("plot.type", "violin", envir=envir)
 
     out <- iSEE:::.downsample_points(all_memory$colDataPlot[1, ], envir)
     expect_identical(out, c(
@@ -1750,7 +1750,7 @@ test_that("2d density contours can be added to scatter plots ", {
         "x_lab", "y_lab", "color_lab", "shape_lab", "size_lab", "title",
         by_row=FALSE, is_subsetted=TRUE, is_downsampled=FALSE)
 
-    expect_identical(out[["contours"]], "geom_density_2d(aes(x = X, y = Y), plot.data, colour='blue') +")
+    expect_identical(out[["contours"]], "geom_density_2d(aes(x=X, y=Y), plot.data, colour='blue') +")
 
 })
 
@@ -1758,7 +1758,7 @@ test_that("2d density contours can be added to scatter plots ", {
 
 test_that("plots subsetted to no data contain a geom_blank command", {
 
-    geom_blank_cmd <- "geom_blank(data = plot.data.all, inherit.aes = FALSE, aes(x = X, y = Y)) +"
+    geom_blank_cmd <- "geom_blank(data=plot.data.all, inherit.aes=FALSE, aes(x=X, y=Y)) +"
 
     # .scatter_plot
 
@@ -1872,7 +1872,7 @@ test_that(".self_brush_box can flip axes", {
     all_memory$colDataPlot[[iSEE:::.brushData]][[1]] <- list(brushData)
 
     out <- iSEE:::.self_brush_box(all_memory$colDataPlot, flip=TRUE)
-    expect_match(out, "aes(xmin = ymin, xmax = ymax, ymin = xmin, ymax = xmax)", fixed=TRUE)
+    expect_match(out, "aes(xmin=ymin, xmax=ymax, ymin=xmin, ymax=xmax)", fixed=TRUE)
 
 })
 
@@ -1892,13 +1892,13 @@ test_that(".self_brush_box flip axes when faceting on both X and Y", {
     # Check that row and column are flipped (to panelvar2 and panelvar1)
     expect_match(
         out,
-        "list(FacetRow = all_brushes[['colDataPlot1']][['panelvar2']], FacetColumn = all_brushes[['colDataPlot1']][['panelvar1']])",
+        "list(FacetRow=all_brushes[['colDataPlot1']][['panelvar2']], FacetColumn=all_brushes[['colDataPlot1']][['panelvar1']])",
         fixed=TRUE)
 
     # Check that the faceting data is appended to the brush data
     expect_match(
         out,
-        "do.call(data.frame, append(all_brushes[['colDataPlot1']][c('xmin', 'xmax', 'ymin', 'ymax')], list(FacetRow = all_brushes[['colDataPlot1']][['panelvar2']], FacetColumn = all_brushes[['colDataPlot1']][['panelvar1']])))", fixed=TRUE
+        "do.call(data.frame, append(all_brushes[['colDataPlot1']][c('xmin', 'xmax', 'ymin', 'ymax')], list(FacetRow=all_brushes[['colDataPlot1']][['panelvar2']], FacetColumn=all_brushes[['colDataPlot1']][['panelvar1']])))", fixed=TRUE
     )
 
 })
@@ -1922,12 +1922,12 @@ test_that(".self_lasso_path works with multiple lassos", {
 
     out <- iSEE:::.self_lasso_path(all_memory$colDataPlot)
     expect_type(out, "character")
-    # length = (polygon+text)*2 lassos + scale_fill_manual + guides
+    # length=(polygon+text)*2 lassos + scale_fill_manual + guides
     expect_length(out, 2*length(lassoHistory)+2)
-    expect_match(out[1], "geom_polygon", fixed = TRUE)
-    expect_match(out[2], "geom_text", fixed = TRUE)
-    expect_match(out[3], "scale_fill_manual", fixed = TRUE)
-    expect_match(out[4], "guides(shape = 'none')", fixed = TRUE)
+    expect_match(out[1], "geom_polygon", fixed=TRUE)
+    expect_match(out[2], "geom_text", fixed=TRUE)
+    expect_match(out[3], "scale_fill_manual", fixed=TRUE)
+    expect_match(out[4], "guides(shape='none')", fixed=TRUE)
 })
 
 test_that(".self_lasso_path flip axes when faceting on both X and Y", {
@@ -1951,20 +1951,20 @@ test_that(".self_lasso_path flip axes when faceting on both X and Y", {
     # Check that row and column are flipped (to panelvar2 and panelvar1)
     expect_match(
         out[1],
-        "FacetRow = all_lassos[['colDataPlot1']][['panelvar2']], FacetColumn = all_lassos[['colDataPlot1']][['panelvar1']]",
+        "FacetRow=all_lassos[['colDataPlot1']][['panelvar2']], FacetColumn=all_lassos[['colDataPlot1']][['panelvar1']]",
         fixed=TRUE)
 
     # Check that the faceting data is appended to the brush data
     expect_match(
         out[1],
-        "data.frame(X = all_lassos[['colDataPlot1']]$coord[,1], Y = all_lassos[['colDataPlot1']]$coord[,2], FacetRow = all_lassos[['colDataPlot1']][['panelvar2']], FacetColumn = all_lassos[['colDataPlot1']][['panelvar1']])", fixed=TRUE
+        "data.frame(X=all_lassos[['colDataPlot1']]$coord[, 1], Y=all_lassos[['colDataPlot1']]$coord[, 2], FacetRow=all_lassos[['colDataPlot1']][['panelvar2']], FacetColumn=all_lassos[['colDataPlot1']][['panelvar1']])", fixed=TRUE
     )
 
     expect_identical(
         out[2],
-        "scale_fill_manual(values = c('TRUE' = '#DB0230', 'FALSE' = '#F7CCD5'), labels = NULL)")
+        "scale_fill_manual(values=c('TRUE'='#DB0230', 'FALSE'='#F7CCD5'), labels=NULL)")
 
-    expect_identical(out[3], "guides(shape = 'none')")
+    expect_identical(out[3], "guides(shape='none')")
 
 })
 
@@ -2011,11 +2011,10 @@ test_that(".self_lasso_path uses the size aesthetic to distinguish waypoints of 
     expect_identical(
         out,
         c(
-            "geom_path(aes(x = X, y = Y),\n    data=data.frame(X = all_lassos[['redDimPlot1']]$coord[,1], Y = all_lassos[['redDimPlot1']]$coord[,2]),\n    inherit.aes=FALSE, alpha=1, color='#3565AA', linetype = 'longdash')",
-            "geom_point(aes(x = X, y = Y, size = First),\n    data=data.frame(X = all_lassos[['redDimPlot1']]$coord[,1], Y = all_lassos[['redDimPlot1']]$coord[,2],\n        First = seq_len(nrow(all_lassos[['redDimPlot1']]$coord))==1L),\n    inherit.aes=FALSE, alpha=1, stroke = 1, shape = 22, color = '#3565AA')",
-            "scale_size_manual(values = c('TRUE' = 1.5, 'FALSE' = 0.25))",
-            "guides(size = 'none')")
+            "geom_path(aes(x=X, y=Y),\n    data=data.frame(X=all_lassos[['redDimPlot1']]$coord[, 1], Y=all_lassos[['redDimPlot1']]$coord[, 2]),\n    inherit.aes=FALSE, alpha=1, color='#3565AA', linetype='longdash')",
+            "geom_point(aes(x=X, y=Y, size=First),\n    data=data.frame(X=all_lassos[['redDimPlot1']]$coord[, 1], Y=all_lassos[['redDimPlot1']]$coord[, 2],\n        First=seq_len(nrow(all_lassos[['redDimPlot1']]$coord)) == 1L),\n    inherit.aes=FALSE, alpha=1, stroke=1, shape=22, color='#3565AA')",
+            "scale_size_manual(values=c('TRUE'=1.5, 'FALSE'=0.25))",
+            "guides(size='none')")
     )
 
 })
-

--- a/vignettes/basic.Rmd
+++ b/vignettes/basic.Rmd
@@ -103,8 +103,7 @@ Then, we normalize the expression values with `r Biocpkg("scater")`.
 
 ```{r}
 library(scater)
-counts(sce) <- assay(sce, "tophat_counts")
-sce <- normalize(sce)
+sce <- logNormCounts(sce, exprs_values="tophat_counts")
 ```
 
 Next, we apply PCA and *t*-SNE to generate two low-dimensional representations of the cells.


### PR DESCRIPTION
substitute calls to normalize by logNormCounts; directly use original "tophat_counts" instead of "counts" copy; apply coding guidelines for space in reported code; update tests accordingly; version bump.