### PR TITLE
define non-empty lasso to fix test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: iSEE
 Title: Interactive SummarizedExperiment Explorer
-Version: 1.5.9
-Date: 2019-09-03
+Version: 1.5.10
+Date: 2019-09-19
 Authors@R: c(person("Kevin", "Rue-Albrecht", role = "aut", email = "kevin.rue-albrecht@kennedy.ox.ac.uk", comment = c(ORCID = "0000-0003-3899-3872")),
     person("Federico", "Marini", role="aut", email="marinif@uni-mainz.de", comment = c(ORCID = '0000-0003-3252-7758')),
     person("Charlotte", "Soneson", role=c("aut", "cre"), email="charlottesoneson@gmail.com", comment = c(ORCID = '0000-0003-3833-2169')),

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,6 +1,12 @@
 \name{NEWS}
 \title{News for Package 'iSEE'}
 
+\section{iSEE VERSION 1.5.10}{
+\itemize{
+    \item Fix test to provide a non-empty selection to custom plot function.
+}
+}
+
 \section{iSEE VERSION 1.5.9}{
 \itemize{
     \item Introduce Bugs Easter egg.

--- a/man/iSEE.Rd
+++ b/man/iSEE.Rd
@@ -85,7 +85,8 @@ If not provided, the app displays the version info of \code{\link{iSEE}}.}
 
 \item{voice}{A logical indicating whether the voice recognition should be enabled.}
 
-\item{bugs}{Set to \code{TRUE} to enable the bugs Easter egg or a named numeric vector to control their respective number (e.g., \code{c(bugs=3, spiders=1)}).
+\item{bugs}{Set to \code{TRUE} to enable the bugs Easter egg.
+Alternatively, a named numeric vector control the respective number of each bug type (e.g., \code{c(bugs=3L, spiders=1L)}).
 Credits to https://github.com/Auz/Bug for the JavaScript code.}
 }
 \value{

--- a/tests/testthat/test_custom.R
+++ b/tests/testthat/test_custom.R
@@ -138,8 +138,12 @@ test_that(".make_customDataPlot responds to a transmitting column brush receiver
         panelvar1=NULL, panelvar2=NULL,
         mapping=list(x="X", y="Y"),
         coord=matrix(c(
-            1, 10,  1, 1,
-            1, 10, 10, 1), ncol=2))
+            -50, -25,
+            -25, -25,
+            -25, 50,
+            -50, 50,
+            -50, -25),
+            ncol=2, byrow = TRUE))
     all_memory$redDimPlot[[iSEE:::.lassoData]][[1]] <- LASSO_CLOSED
 
     r.out <- iSEE:::.make_redDimPlot(id =1, all_memory, all_coordinates, sceX, ExperimentColorMap())


### PR DESCRIPTION
Ideally, we should still keep a copy of the old test and understand why it fails with the following error (Mac OS X)
```
>     p.out2 <- iSEE:::.make_customDataPlot(id=1, all_memory, all_coordinates, sceX)
Error in (function (A, nv = 5, nu = nv, maxit = 1000, work = nv + 7, reorth = TRUE,  : 
  max(nu, nv) must be positive
In addition: Warning messages:
1: 'scale_features' is deprecated.
Use 'scale' instead.
See help("Deprecated") 
2: In check_numbers(k = k, nu = nu, nv = nv, limit = min(dim(x)) -  :
 
 Error in (function (A, nv = 5, nu = nv, maxit = 1000, work = nv + 7, reorth = TRUE,  : 
  max(nu, nv) must be positive 
```