### PR TITLE
Refactor more heat

### DIFF
--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -425,12 +425,22 @@ setClass("HeatMapPlot", contains="Panel", slots=collated)
 .heatMapColData <- "ColData"
 .heatMapRowData <- "RowData"
 
+.heatMapFeatNameText <- "FeatNameText"
+.heatMapSampNameText <- "SampNameText"
+.heatMapCustomFeatNames <- "CustomFeatName"
+.heatMapCustomSampNames <- "CustomSampName"
+
 collated <- character(0)
 collated[.heatMapAssay] <- "character"
 collated[.heatMapRownames] <- "character"
 collated[.heatMapColnames] <- "character"
 collated[.heatMapColData] <- "character"
 collated[.heatMapRowData] <- "character"
+
+collated[.heatMapCustomFeatNames] <- "logical"
+collated[.heatMapFeatNameText] <- "character"
+collated[.heatMapCustomSampNames] <- "logical"
+collated[.heatMapSampNameText] <- "character"
 
 .visualParamBoxOpen <- "VisualBoxOpen"
 

--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -439,10 +439,10 @@ collated[.heatMapRowData] <- "character"
 
 collated[.heatMapCustomFeatNames] <- "logical"
 collated[.heatMapFeatNameText] <- "character"
-collated[.heatMapCustomSampNames] <- "logical"
-collated[.heatMapSampNameText] <- "character"
 
-.visualParamBoxOpen <- "VisualBoxOpen"
+collated[.selectEffect] <- "character"
+collated[.selectColor] <- "character"
+collated[.selectTransAlpha] <- "numeric"
 
 collated[.visualParamBoxOpen] <- "logical"
 


### PR DESCRIPTION
Begins to implement the previously discussed idea for the heatmap refactoring. It is now `.generateOutput`'s responsibility to deparse the text in order to obtain sensible row/column names that can be put into the code for heatmap construction.