### PR TITLE
Cleaned up .multiSelectionResponsive code and documentation.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: iSEE
 Title: Interactive SummarizedExperiment Explorer
-Version: 2.19.1
-Date: 2024-11-22
+Version: 2.19.2
+Date: 2024-12-09
 Authors@R: c(
     person("Kevin", "Rue-Albrecht", role = c("aut", "cre"), email = "kevinrue67@gmail.com", comment = c(ORCID = "0000-0003-3899-3872")),
     person("Federico", "Marini", role="aut", email="marinif@uni-mainz.de", comment = c(ORCID = '0000-0003-3252-7758')),

--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -743,7 +743,8 @@ setGeneric(".cacheCommonInfo", function(x, se) standardGeneric(".cacheCommonInfo
 #' \code{.multiSelectionInvalidated(x)} should return a logical scalar indicating whether a transmission of a multiple selection to \code{x} invalidates \code{x}'s own existing selections.
 #' This should only be \code{TRUE} in special circumstances, e.g., if receipt of a new multiple selection causes recalculation of coordinates in a \linkS4class{DotPlot}.
 #' 
-#' \code{.multiSelectionResponsive(x, dims)} should return a logical scalar indicating whether \code{x} is responsive to an incoming multiple selection on dimensions \code{dims}.
+#' \code{.multiSelectionResponsive(x, dim)} should return a logical scalar indicating whether \code{x} is responsive to an incoming multiple selection on dimension \code{dim}.
+#' \code{dim} is equal to \code{"row"} if the multiple selection of rows, otherwise it is equal to \code{"column"} for a multiple selection of columns.
 #' For example, the method for \linkS4class{ComplexHeatmapPlot} would return \code{TRUE} when an incoming selection originates from a row-oriented panel and \code{CustomRows=FALSE}.
 #' Otherwise, it would be \code{FALSE} as the dimension of the transmitted selection is dismissed by the options of the child panel.
 #'
@@ -782,7 +783,7 @@ setGeneric(".multiSelectionInvalidated", function(x) standardGeneric(".multiSele
 setGeneric(".multiSelectionAvailable", function(x, contents) standardGeneric(".multiSelectionAvailable"))
 
 #' @export
-setGeneric(".multiSelectionResponsive", function(x, dims) standardGeneric(".multiSelectionResponsive"))
+setGeneric(".multiSelectionResponsive", function(x, dim) standardGeneric(".multiSelectionResponsive"))
 
 #' @export
 setGeneric(".isBrushable", function(x) standardGeneric(".isBrushable"))

--- a/R/createCustomPanels.R
+++ b/R/createCustomPanels.R
@@ -127,7 +127,7 @@ createCustomTable <- function(FUN, restrict=NULL, className="CustomTable",
         }
     }, where = where)
     
-    setMethod(".multiSelectionResponsive", className, function(x) {
+    setMethod(".multiSelectionResponsive", className, function(x, dim) {
         TRUE
     }, where = where)
 

--- a/R/family_ColumnDotPlot.R
+++ b/R/family_ColumnDotPlot.R
@@ -334,12 +334,7 @@ setMethod(".multiSelectionInvalidated", "ColumnDotPlot", function(x) {
 })
 
 #' @export
-setMethod(".multiSelectionResponsive", "ColumnDotPlot", function(x, dims = character(0)) {
-    if ("column" %in% dims) {
-        return(TRUE)
-    }
-    return(FALSE)
-})
+setMethod(".multiSelectionResponsive", "ColumnDotPlot", function(x, dim) dim == "column")
 
 #' @export
 setMethod(".singleSelectionDimension", "ColumnDotPlot", function(x) "sample")

--- a/R/family_ColumnTable.R
+++ b/R/family_ColumnTable.R
@@ -114,12 +114,7 @@ setMethod(".multiSelectionDimension", "ColumnTable", function(x) "column")
 setMethod(".singleSelectionDimension", "ColumnTable", function(x) "sample")
 
 #' @export
-setMethod(".multiSelectionResponsive", "ColumnTable", function(x, dims = character(0)) {
-    if ("column" %in% dims) {
-        return(TRUE)
-    }
-    return(FALSE)
-})
+setMethod(".multiSelectionResponsive", "ColumnTable", function(x, dim) dim == "column")
 
 #' @export
 setMethod(".hideInterface", "ColumnTable", function(x, field) {

--- a/R/family_Panel.R
+++ b/R/family_Panel.R
@@ -102,6 +102,7 @@
 #' \item \code{\link{.multiSelectionClear}(x)} will always return \code{x}.
 #' \item \code{\link{.multiSelectionInvalidated}(x)} will always return \code{FALSE}.
 #' \item \code{\link{.multiSelectionAvailable}(x, contents)} will return \code{nrow(contents)}.
+#' \item \code{\link{.multiSelectionResponsive}(x, dim)} will always return \code{TRUE}.
 #' \item \code{\link{.singleSelectionDimension}(x)} will always return \code{"none"}.
 #' \item \code{\link{.singleSelectionValue}(x)} will always return \code{NULL}.
 #' \item \code{\link{.singleSelectionSlots}(x)} will always return an empty list.
@@ -145,6 +146,7 @@
 #' .multiSelectionActive,Panel-method
 #' .multiSelectionInvalidated,Panel-method
 #' .multiSelectionAvailable,Panel-method
+#' .multiSelectionResponsive,Panel-method
 #' .isBrushable,Panel-method
 #' .singleSelectionDimension,Panel-method
 #' .singleSelectionValue,Panel-method
@@ -652,6 +654,9 @@ setMethod(".multiSelectionInvalidated", "Panel", function(x) FALSE)
 
 #' @export
 setMethod(".multiSelectionAvailable", "Panel", function(x, contents) nrow(contents))
+
+#' @export
+setMethod(".multiSelectionResponsive", "Panel", function(x, dim) TRUE)
 
 #' @export
 setMethod(".isBrushable", "Panel", function(x) FALSE)

--- a/R/family_RowDotPlot.R
+++ b/R/family_RowDotPlot.R
@@ -332,12 +332,7 @@ setMethod(".multiSelectionInvalidated", "RowDotPlot", function(x) {
 })
 
 #' @export
-setMethod(".multiSelectionResponsive", "RowDotPlot", function(x, dims = character(0)) {
-    if ("row" %in% dims) {
-        return(TRUE)
-    }
-    return(FALSE)
-})
+setMethod(".multiSelectionResponsive", "RowDotPlot", function(x, dim) dim == "row")
 
 #' @export
 setMethod(".singleSelectionDimension", "RowDotPlot", function(x) "feature")

--- a/R/family_RowTable.R
+++ b/R/family_RowTable.R
@@ -123,12 +123,7 @@ setMethod(".multiSelectionDimension", "RowTable", function(x) "row")
 setMethod(".singleSelectionDimension", "RowTable", function(x) "feature")
 
 #' @export
-setMethod(".multiSelectionResponsive", "RowTable", function(x, dims = character(0)) {
-    if ("row" %in% dims) {
-        return(TRUE)
-    }
-    return(FALSE)
-})
+setMethod(".multiSelectionResponsive", "RowTable", function(x, dim) dim == "row")
 
 #' @export
 setMethod(".showSelectionDetails", "RowTable", function(x) {

--- a/R/panel_ComplexHeatmapPlot.R
+++ b/R/panel_ComplexHeatmapPlot.R
@@ -750,20 +750,18 @@ setMethod(".multiSelectionRestricted", "ComplexHeatmapPlot", function(x) {
 })
 
 #' @export
-setMethod(".multiSelectionResponsive", "ComplexHeatmapPlot", function(x, dims = character(0)) {
-    if ("row" %in% dims) {
+setMethod(".multiSelectionResponsive", "ComplexHeatmapPlot", function(x, dim) {
+    if (dim == "row") {
         if (slot(x, .selectRowRestrict) || !slot(x, .heatMapCustomFeatNames)) {
             return(TRUE)
         }
-    }
-    if ("column" %in% dims) {
+    } else {
         if (slot(x, .selectColumnRestrict) || slot(x, .heatMapShowSelection)) {
             return(TRUE)
         }
     }
     return(FALSE)
 })
-
 
 ###############################################################
 

--- a/man/Panel-class.Rd
+++ b/man/Panel-class.Rd
@@ -22,6 +22,7 @@
 \alias{.multiSelectionActive,Panel-method}
 \alias{.multiSelectionInvalidated,Panel-method}
 \alias{.multiSelectionAvailable,Panel-method}
+\alias{.multiSelectionResponsive,Panel-method}
 \alias{.isBrushable,Panel-method}
 \alias{.singleSelectionDimension,Panel-method}
 \alias{.singleSelectionValue,Panel-method}
@@ -137,6 +138,7 @@ For controlling selections:
 \item \code{\link{.multiSelectionClear}(x)} will always return \code{x}.
 \item \code{\link{.multiSelectionInvalidated}(x)} will always return \code{FALSE}.
 \item \code{\link{.multiSelectionAvailable}(x, contents)} will return \code{nrow(contents)}.
+\item \code{\link{.multiSelectionResponsive}(x, dim)} will always return \code{TRUE}.
 \item \code{\link{.singleSelectionDimension}(x)} will always return \code{"none"}.
 \item \code{\link{.singleSelectionValue}(x)} will always return \code{NULL}.
 \item \code{\link{.singleSelectionSlots}(x)} will always return an empty list.

--- a/man/iSEE-pkg.Rd
+++ b/man/iSEE-pkg.Rd
@@ -16,7 +16,7 @@
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://github.com/iSEE/iSEE}
+  \item \url{https://isee.github.io/iSEE/}
   \item Report bugs at \url{https://github.com/iSEE/iSEE/issues}
 }
 

--- a/man/multi-select-generics.Rd
+++ b/man/multi-select-generics.Rd
@@ -90,7 +90,8 @@ Otherwise, it would be \code{FALSE} as the transmitted selection is only used fo
 \code{.multiSelectionInvalidated(x)} should return a logical scalar indicating whether a transmission of a multiple selection to \code{x} invalidates \code{x}'s own existing selections.
 This should only be \code{TRUE} in special circumstances, e.g., if receipt of a new multiple selection causes recalculation of coordinates in a \linkS4class{DotPlot}.
 
-\code{.multiSelectionResponsive(x, dims)} should return a logical scalar indicating whether \code{x} is responsive to an incoming multiple selection on dimensions \code{dims}.
+\code{.multiSelectionResponsive(x, dim)} should return a logical scalar indicating whether \code{x} is responsive to an incoming multiple selection on dimension \code{dim}.
+\code{dim} is equal to \code{"row"} if the multiple selection of rows, otherwise it is equal to \code{"column"} for a multiple selection of columns.
 For example, the method for \linkS4class{ComplexHeatmapPlot} would return \code{TRUE} when an incoming selection originates from a row-oriented panel and \code{CustomRows=FALSE}.
 Otherwise, it would be \code{FALSE} as the dimension of the transmitted selection is dismissed by the options of the child panel.
 }

--- a/tests/testthat/test_api.R
+++ b/tests/testthat/test_api.R
@@ -282,7 +282,9 @@ test_that(".multiSelectionRestricted handles ComplexHeatmapPlot", {
         ColumnSelectionRestrict = FALSE,
         RowSelectionRestrict = FALSE
     )
-    out <- .multiSelectionResponsive(x, c("row", "column"))
+    out <- .multiSelectionResponsive(x, "row")
+    expect_false(out)
+    out <- .multiSelectionResponsive(x, "column")
     expect_false(out)
     
     # enable incoming row selection


### PR DESCRIPTION
The 'dims' argument now only accepts a single dimension, either row or column; this is possible as the entire .multiSelectionResponsive generic is only called in one place with a non-"none" output from .multiSelectionDimension(). It allows us to greatly simplify the implementation of various methods.

Updated the documentation and signature to mention the new expectations. Also added a default Panel method that conservatively requires a re-render upon any multiple selection; subclasses can refine this for efficiency.