### PR TITLE
Allow submatrix extraction to skip coercion to an ordinary matrix.

### DIFF
--- a/man/extractAssaySubmatrix.Rd
+++ b/man/extractAssaySubmatrix.Rd
@@ -4,7 +4,14 @@
 \alias{.extractAssaySubmatrix}
 \title{Extract assay submatrix}
 \usage{
-.extractAssaySubmatrix(x, se, envir, use_custom_row_slot, custom_row_text_slot)
+.extractAssaySubmatrix(
+  x,
+  se,
+  envir,
+  use_custom_row_slot,
+  custom_row_text_slot,
+  as_matrix = TRUE
+)
 }
 \arguments{
 \item{x}{A \linkS4class{Panel} instance that uses the row selection modal.}
@@ -18,6 +25,9 @@ This assumes that \code{\link{.processMultiSelections}} has already been run.}
 
 \item{custom_row_text_slot}{String specifying the name of the slot holding the custom row names.
 This is expected to be of the same format as described in \code{?\link{.createCustomDimnamesModalObservers}}.}
+
+\item{as_matrix}{Logical scalar indicating whether to coerce the submatrix into an ordinary matrix.
+If \code{FALSE}, the existing matrix representation is preserved.}
 }
 \value{
 A character vector of commands to set up the assay submatrix.

--- a/tests/testthat/test_heatmap.R
+++ b/tests/testthat/test_heatmap.R
@@ -187,7 +187,7 @@ test_that(".generateOutput detects col_selected and row_selected", {
     out <- .generateOutput(memory$ComplexHeatmapPlot1, sce, all_memory = memory, all_contents = pObjects$contents)
     expect_identical(out$commands$assay[["rows"]], '.chosen.rows <- c("Lamp5", "Fam19a1");')
     expect_identical(out$commands$assay[["columns"]], '.chosen.columns <- intersect(colnames(se), unlist(col_selected));')
-    expect_identical(out$commands$assay[["data"]], 'plot.data <- assay(se, "logcounts")[.chosen.rows, .chosen.columns, drop=FALSE]\nplot.data <- as.matrix(plot.data);')
+    expect_identical(out$commands$assay[["data"]], 'plot.data <- assay(se, "logcounts")[.chosen.rows, .chosen.columns, drop=FALSE];\nplot.data <- as.matrix(plot.data);')
 })
 
 test_that(".generateOutput handles row_selected when not using custom feature names", {
@@ -383,3 +383,22 @@ test_that("constructor concatenates newlines in text", {
     expect_identical(stored, paste(LETTERS, collapse="\n"))
 
 })
+
+test_that(".extractAssaySubmatrix works without coercion to matrix", {
+
+    evalenv <- new.env()
+    evalenv$se <- sce
+    evalenv$row_selected <- head(rownames(sce))
+    evalenv$col_selected <- head(colnames(sce))
+
+    x <- ComplexHeatmapPlot(CustomRows=FALSE, ColumnSelectionRestrict=TRUE)
+    extracted <- .extractAssaySubmatrix(x, sce, evalenv, 
+        use_custom_row_slot=iSEE:::.heatMapCustomFeatNames,
+        custom_row_text_slot=iSEE:::.heatMapFeatNameText,
+        as_matrix=FALSE
+    )
+
+    expect_identical(extracted[["data"]], 'plot.data <- assay(se, "logcounts")[.chosen.rows, .chosen.columns, drop=FALSE];')
+    expect_identical(dim(evalenv$plot.data), c(length(evalenv$row_selected), length(evalenv$col_selected)))
+})
+


### PR DESCRIPTION
This is useful to avoid unnecessary loss of sparsity, e.g., if the submatrix is to be used in more calculations before the actual plotting.