### PR TITLE
Added tabTitle argument for iSEE

### DIFF
--- a/R/iSEE-main.R
+++ b/R/iSEE-main.R
@@ -17,6 +17,8 @@
 #' Ignored if \code{se} is not supplied.
 #' @param appTitle A string indicating the title to be displayed in the app.
 #' If not provided, the app displays the version info of \code{\link{iSEE}}.
+#' @param tabTitle A string indicating the title to be displayed in the browser
+#' tab. If not provided, the tab is named \code{"iSEE"}.
 #' @param runLocal A logical indicating whether the app is to be run locally or remotely on a server, which determines how documentation will be accessed.
 #' @param voice A logical indicating whether the voice recognition should be enabled.
 #' @param bugs Set to \code{TRUE} to enable the bugs Easter egg.
@@ -119,6 +121,7 @@ iSEE <- function(se,
     landingPage=createLandingPage(),
     tour=NULL,
     appTitle=NULL,
+    tabTitle=NULL,
     runLocal=TRUE,
     voice=FALSE,
     bugs=FALSE,
@@ -157,6 +160,7 @@ iSEE <- function(se,
     #######################################################################
 
     iSEE_ui <- dashboardPage(
+        title = ifelse(is.null(tabTitle), "iSEE", tabTitle),
         dashboardHeader(
             title = .set_title(appTitle),
             titleWidth = 750,

--- a/man/iSEE.Rd
+++ b/man/iSEE.Rd
@@ -12,6 +12,7 @@ iSEE(
   landingPage = createLandingPage(),
   tour = NULL,
   appTitle = NULL,
+  tabTitle = NULL,
   runLocal = TRUE,
   voice = FALSE,
   bugs = FALSE,
@@ -40,6 +41,9 @@ Ignored if \code{se} is not supplied.}
 
 \item{appTitle}{A string indicating the title to be displayed in the app.
 If not provided, the app displays the version info of \code{\link{iSEE}}.}
+
+\item{tabTitle}{A string indicating the title to be displayed in the browser
+tab. If not provided, the tab is named \code{"iSEE"}.}
 
 \item{runLocal}{A logical indicating whether the app is to be run locally or remotely on a server, which determines how documentation will be accessed.}
 


### PR DESCRIPTION
Hi!

As discussed in the [miaDash submission to Bioc](https://github.com/Bioconductor/Contributions/issues/3637#issuecomment-2755726175), the tab title for miaDash is currently derived from the `dashboardHeader` title and therefore is not rendered correctly when the title is an HTML element, like for miaDash.

![Screenshot 2025-04-01 at 23 05 09](https://github.com/user-attachments/assets/6bc5d805-ff0c-445d-ad24-2117922aad4d)


Therefore, I added a new argument to the `iSEE` function called `tabTitle`, which lets you modify the name of the browser tab without affecting the app title or other elements. For example, for the ISEE app:

![Screenshot 2025-04-01 at 23 02 38](https://github.com/user-attachments/assets/84412b4e-2bfe-4810-bd52-315f4810fe01)

Feel free to let me know if this solution suits iSEE and if anything should be changed.

Best,
Giulio
